### PR TITLE
Change byte array size to 20 as it is max size of godot's variant

### DIFF
--- a/tools/api-classes-generator/src/main/kotlin/ICall.kt
+++ b/tools/api-classes-generator/src/main/kotlin/ICall.kt
@@ -75,7 +75,7 @@ class ICall(
                 )
             } else {
                 codeBlockBuilder.add(
-                        "    val retVar = %M<%T>(8)\n",
+                        "    val retVar = %M<%T>(20)\n",
                         MemberName("kotlinx.cinterop", "allocArray"),
                         ClassName("kotlinx.cinterop", "ByteVar")
                 )


### PR DESCRIPTION
This fixes #6 by allocating a byte array of size 20, as it is max godot's Variant size.
This enables to run samples project on OSX.
Also there are still some memory leaks in our bindings, I think we should make another issue for this one, so that we can quick fix crashes on macos.