### PR TITLE
Feature/update to godot 3.2

### DIFF
--- a/API_DIFFERENCES.md
+++ b/API_DIFFERENCES.md
@@ -24,7 +24,7 @@ This happens because in this way you are modifying the local copy of `position`,
 ```kotlin
     override fun _ready() {
         position { 
-            it.x = 5.0
+            x = 5.0
         }
     }
 ```
@@ -32,9 +32,9 @@ This happens because in this way you are modifying the local copy of `position`,
 Which is the same as:
 ```kotlin
     override fun _ready() {
-        val it = position
-        it.x = 5.0
-        position = it
+        val tmp = position
+        tmp.x = 5.0
+        position = tmp
     }
 ```
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+val platform: String by project
+
 buildscript {
     repositories {
         mavenLocal()
@@ -51,28 +53,30 @@ kotlin {
         }
     }
 
-    val targets = listOf(
-            targetFromPreset(presets["godotMingwX64"], "windows"),
-            targetFromPreset(presets["godotLinuxX64"], "linux"),
-            targetFromPreset(presets["godotMacosX64"], "macos")
-    )
+    val target = if (project.hasProperty("platform")) {
+        when(platform) {
+            "windows" -> targetFromPreset(presets["godotMingwX64"], "windows")
+            "linux" -> targetFromPreset(presets["godotLinuxX64"], "linux")
+            "macos" -> targetFromPreset(presets["godotMacosX64"], "macos")
+            else -> targetFromPreset(presets["godotMacosX64"], "macos")
+        }
+    }
+    else targetFromPreset(presets["godotMacosX64"], "macos")
 
-    targets.forEach { target ->
-        target.compilations.getByName("main") {
-            if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
-                println("Configuring target ${target.name}")
-                this.target.binaries {
-                    sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
-                }
-                target.compilations.all {
-                    dependencies {
-                        implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                        implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
-                    }
-                }
-            } else {
-                System.err.println("Not a native target! TargetName: ${target.name}")
+    target.compilations.getByName("main") {
+        if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
+            println("Configuring target ${target.name}")
+            this.target.binaries {
+                sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
             }
+            target.compilations.all {
+                dependencies {
+                    implementation("org.godotengine.kotlin:godot-library:1.0.0")
+                    implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                }
+            }
+        } else {
+            System.err.println("Not a native target! TargetName: ${target.name}")
         }
     }
 }

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -53,30 +53,38 @@ kotlin {
         }
     }
 
-    val target = if (project.hasProperty("platform")) {
-        when(platform) {
-            "windows" -> targetFromPreset(presets["godotMingwX64"], "windows")
-            "linux" -> targetFromPreset(presets["godotLinuxX64"], "linux")
-            "macos" -> targetFromPreset(presets["godotMacosX64"], "macos")
-            else -> targetFromPreset(presets["godotMacosX64"], "macos")
+    val targets = if (project.hasProperty("platform")) {
+        when (platform) {
+            "windows" -> listOf(targetFromPreset(presets["godotMingwX64"], "windows"))
+            "linux" -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
+            "macos" -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
+            else -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
         }
+    } else {
+        listOf(
+                targetFromPreset(presets["godotLinuxX64"], "linux"),
+                targetFromPreset(presets["godotMacosX64"], "macos"),
+                targetFromPreset(presets["godotMingwX64"], "windows")
+        )
     }
-    else targetFromPreset(presets["godotMacosX64"], "macos")
 
-    target.compilations.getByName("main") {
-        if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
-            println("Configuring target ${target.name}")
-            this.target.binaries {
-                sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
-            }
-            target.compilations.all {
-                dependencies {
-                    implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                    implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+    targets.forEach {
+        it.compilations.getByName("main") {
+            if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
+                println("Configuring target ${target.name}")
+                this.target.binaries {
+                    sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
                 }
+                target.compilations.all {
+                    dependencies {
+                        implementation("org.godotengine.kotlin:godot-library:1.0.0")
+                        implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                    }
+                }
+            } else {
+                System.err.println("Not a native target! TargetName: ${target.name}")
             }
-        } else {
-            System.err.println("Not a native target! TargetName: ${target.name}")
         }
     }
 }
+

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -71,11 +71,11 @@ kotlin {
     targets.forEach {
         it.compilations.getByName("main") {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
-                println("Configuring target ${target.name}")
+                println("Configuring target ${this.target.name}")
                 this.target.binaries {
                     sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
                 }
-                target.compilations.all {
+                this.target.compilations.all {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library:1.0.0")
                         implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
@@ -24,11 +24,11 @@ class Player: KinematicBody() {
 
             if(translation.x + velocity.x * delta < 4.0 &&
                     translation.x + velocity.x * delta > -4.0)
-                translation { it.x += velocity.x * delta }
+                translation { x += velocity.x * delta }
 
             if (translation.z + velocity.z * delta < 4.0 &&
                     translation.z + velocity.z * delta > -4.0)
-                translation { it.z += velocity.z * delta }
+                translation { z += velocity.z * delta }
         }
     }
 }

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
@@ -45,11 +45,27 @@ class Player: Area2D() {
 
         position += velocity * delta
 
-        if (position.x < 0) position.x = 0.0
-        else if (position.x > screensize.x) position.x = screensize.x
+        if (position.x < 0) {
+            position {
+                it.x = 0.0
+            }
+        }
+        else if (position.x > screensize.x) {
+            position {
+                it.x = screensize.x
+            }
+        }
 
-        if (position.y < 0) position.y = 0.0
-        else if (position.y > screensize.y) position.y = screensize.y
+        if (position.y < 0) {
+            position {
+                it.y = 0.0
+            }
+        }
+        else if (position.y > screensize.y) {
+            position {
+                it.y = screensize.y
+            }
+        }
 
         if (velocity.x != 0.0) {
             playerSprite.setAnimation("right")

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
@@ -5,7 +5,7 @@ import godot.core.NodePath
 import godot.core.Vector2
 
 //TODO: CollisionShape
-class Player: Area2D() {
+class Player : Area2D() {
 
     var speed: Int = 400
     lateinit var screensize: Vector2
@@ -39,9 +39,9 @@ class Player: Area2D() {
         if (velocity.length() != 0.0) {
             velocity = velocity.normalized() * speed.toDouble()
             playerSprite.play()
-        }
-        else
+        } else {
             playerSprite.stop()
+        }
 
         position += velocity * delta
 
@@ -49,8 +49,7 @@ class Player: Area2D() {
             position {
                 it.x = 0.0
             }
-        }
-        else if (position.x > screensize.x) {
+        } else if (position.x > screensize.x) {
             position {
                 it.x = screensize.x
             }
@@ -60,8 +59,7 @@ class Player: Area2D() {
             position {
                 it.y = 0.0
             }
-        }
-        else if (position.y > screensize.y) {
+        } else if (position.y > screensize.y) {
             position {
                 it.y = screensize.y
             }
@@ -71,8 +69,7 @@ class Player: Area2D() {
             playerSprite.setAnimation("right")
             playerSprite.flipV = false
             playerSprite.flipH = velocity.x < 0
-        }
-        else if (velocity.y != 0.0) {
+        } else if (velocity.y != 0.0) {
             playerSprite.setAnimation("up")
             playerSprite.flipH = false
             playerSprite.flipV = velocity.y > 0

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
@@ -47,21 +47,21 @@ class Player : Area2D() {
 
         if (position.x < 0) {
             position {
-                it.x = 0.0
+                x = 0.0
             }
         } else if (position.x > screensize.x) {
             position {
-                it.x = screensize.x
+                x = screensize.x
             }
         }
 
         if (position.y < 0) {
             position {
-                it.y = 0.0
+                y = 0.0
             }
         } else if (position.y > screensize.y) {
             position {
-                it.y = screensize.y
+                y = screensize.y
             }
         }
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/EnemyPath.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/EnemyPath.kt
@@ -12,8 +12,8 @@ class EnemyPath: Path2D() {
         val tween = Tween().apply {
             interpolateProperty(follow, NodePath("unit_offset"), Variant(0), Variant(1), 6.0, Tween.TRANS_LINEAR.toLong(), Tween.EASE_IN_OUT.toLong())
             setRepeat(true)
-            start()
         }
         addChild(tween)
+        tween.start()
     }
 }

--- a/samples/games/project/samples.gdnlib
+++ b/samples/games/project/samples.gdnlib
@@ -9,8 +9,7 @@ reloadable=true
 
 OSX.64="res://libkotlin.dylib"
 OSX.32="res://libkotlin.dylib"
-Windows.64="res://libkotlin.dll"
-Windows.32="res://libkotlin.dll"
+Windows.64="res://kotlin.dll"
 X11.64="res://libkotlin.so"
 
 [dependencies]
@@ -18,5 +17,4 @@ X11.64="res://libkotlin.so"
 OSX.64=[  ]
 OSX.32=[  ]
 Windows.64=[  ]
-Windows.32=[  ]
 X11.64=[  ]

--- a/samples/games/project/samples.gdnlib
+++ b/samples/games/project/samples.gdnlib
@@ -7,12 +7,16 @@ reloadable=true
 
 [entry]
 
+OSX.64="res://libkotlin.dylib"
+OSX.32="res://libkotlin.dylib"
 Windows.64="res://libkotlin.dll"
 Windows.32="res://libkotlin.dll"
 X11.64="res://libkotlin.so"
 
 [dependencies]
 
+OSX.64=[  ]
+OSX.32=[  ]
 Windows.64=[  ]
 Windows.32=[  ]
 X11.64=[  ]

--- a/samples/games/project/samples.gdnlib
+++ b/samples/games/project/samples.gdnlib
@@ -8,13 +8,11 @@ reloadable=true
 [entry]
 
 OSX.64="res://libkotlin.dylib"
-OSX.32="res://libkotlin.dylib"
 Windows.64="res://kotlin.dll"
 X11.64="res://libkotlin.so"
 
 [dependencies]
 
 OSX.64=[  ]
-OSX.32=[  ]
 Windows.64=[  ]
 X11.64=[  ]

--- a/tools/api-classes-generator/src/main/kotlin/Argument.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Argument.kt
@@ -34,7 +34,7 @@ class Argument(
                 "Boolean" -> defaultValue.toLowerCase()
                 "Double" -> intToFloat(defaultValue)
                 "Vector2", "Vector3", "Rect2" -> "$type$defaultValue"
-                "Transform", "Transform2D", "GDArray", "RID", "PoolVector2Array", "PoolStringArray", "PoolVector3Array", "PoolColorArray", "PoolIntArray", "PoolRealArray", "PoolByteArray" -> "$type()"
+                "Dictionary", "Transform", "Transform2D", "GDArray", "RID", "PoolVector2Array", "PoolStringArray", "PoolVector3Array", "PoolColorArray", "PoolIntArray", "PoolRealArray", "PoolByteArray" -> "$type()"
                 "String" -> "\"$defaultValue\""
                 else -> defaultValue
             }

--- a/tools/api-classes-generator/src/main/kotlin/Class.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Class.kt
@@ -176,7 +176,7 @@ class Class(
                     FunSpec.builder("from")
                             .addModifiers(KModifier.INFIX)
                             .addParameter("other", ClassName(if (node.value.name.isCoreType()) "godot.core" else "godot", node.value.name))
-                            .addStatement("return $name(\"\").apply { setRawMemory(other.rawMemory) }").build()
+                            .addStatement("return $name(\"\").apply{ setRawMemory(other.rawMemory) }").build()
             )
             node = node.parent
         }
@@ -238,7 +238,7 @@ class Class(
                             )
                             .returns(parameterTypeName)
                             .addStatement(
-                                    """return $parameterName.apply {
+                                    """return $parameterName.apply{
                                                 |    schedule(this)
                                                 |    $parameterName = this
                                                 |}

--- a/tools/api-classes-generator/src/main/kotlin/Class.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Class.kt
@@ -232,7 +232,7 @@ class Class(
                                     ParameterSpec.builder(
                                             "schedule",
                                             LambdaTypeName.get(
-                                                    parameters = *arrayOf(parameterTypeName),
+                                                    receiver = parameterTypeName,
                                                     returnType = ClassName("kotlin", "Unit")
                                             )
                                     ).build()

--- a/tools/api-classes-generator/src/main/kotlin/Class.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Class.kt
@@ -176,7 +176,8 @@ class Class(
                     FunSpec.builder("from")
                             .addModifiers(KModifier.INFIX)
                             .addParameter("other", ClassName(if (node.value.name.isCoreType()) "godot.core" else "godot", node.value.name))
-                            .addStatement("return $name(\"\").apply{ setRawMemory(other.rawMemory) }").build()
+                            .addStatement("return $name(\"\").apply{ setRawMemory(other.rawMemory) }")
+                            .build()
             )
             node = node.parent
         }

--- a/tools/api-classes-generator/src/main/kotlin/Generator.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Generator.kt
@@ -3,7 +3,7 @@ import com.squareup.kotlinpoet.*
 import java.io.File
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 
-const val GODOT_API_PATH = "godot_api.json"
+const val GODOT_API_PATH = "../../wrapper/lib/godot_headers/api.json"
 const val GENERATED_PATH = "../../wrapper/godot-library/src/main/kotlin/godot/generated/"
 
 fun main() {

--- a/tools/api-classes-generator/src/main/kotlin/Graph.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Graph.kt
@@ -27,8 +27,9 @@ fun List<Class>.buildTree(): Graph<Class> {
 
 
 fun Graph<Class>.doAncestorsHaveMethod(cl: Class, method: Method): Boolean {
-    if (cl.baseClass == "")
-        return false
+    if (method.name == "toString") return true
+
+    if (cl.baseClass == "") return false
 
     fun check(m: Method): Boolean {
         if (m.name == method.name && m.arguments.size == method.arguments.size) {

--- a/tools/api-classes-generator/src/main/kotlin/Method.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Method.kt
@@ -64,7 +64,7 @@ open class Method(
                     if (shouldReturn) "return " else "",
                     if (returnType.isEnum()) {
                         "${returnType.removeEnumPrefix()}.fromInt( "
-                    } else if (hasVarargs && returnType != "Variant") {
+                    } else if (hasVarargs && returnType != "Variant" && returnType != "Unit") {
                         "$returnType from "
                     } else {
                         ""

--- a/tools/api-classes-generator/src/main/kotlin/Property.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Property.kt
@@ -39,6 +39,10 @@ class Property(
     fun generate(clazz: Class, tree: Graph<Class>, icalls: MutableSet<ICall>): PropertySpec? {
         if (!hasValidGetter && !hasValidSetter) return null
 
+        if (hasValidGetter && !validGetter.returnType.isEnum() && type != validGetter.returnType) {
+            type = validGetter.returnType
+        }
+
         // Sorry for this, CPUParticles has "scale" property overrides ancestor's "scale", but mismatches type
         if (clazz.name == "CPUParticles" && name == "scale") name = "_scale"
 

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -23,20 +23,28 @@ kotlin {
         }
     }
 
-    val target =
+    val targets =
             if (project.hasProperty("platform")) {
                 when (platform) {
-                    "windows" -> targetFromPreset(presets["mingwX64"], "windows")
-                    "linux" -> targetFromPreset(presets["linuxX64"], "linux")
-                    "macos" -> targetFromPreset(presets["macosX64"], "macos")
-                    else -> targetFromPreset(presets["linuxX64"], "linux")
+                    "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
+                    "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
+                    "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
+                    else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
-            } else targetFromPreset(presets["linuxX64"], "linux")
+            } else {
+                listOf(
+                        targetFromPreset(presets["linuxX64"], "linux"),
+                        targetFromPreset(presets["macosX64"], "macos"),
+                        targetFromPreset(presets["mingwX64"], "windows")
+                )
+            }
 
-    target.compilations.all {
-        dependencies {
-            implementation(project(":wrapper:godot-library"))
-            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.3")
+    targets.forEach {
+        it.compilations.all {
+            dependencies {
+                implementation(project(":wrapper:godot-library"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.3")
+            }
         }
     }
 }
@@ -45,7 +53,7 @@ tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
 }
 
-if(project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
+if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
         && project.hasProperty("platform")) {
     bintray {
         user = bintrayUser

--- a/wrapper/godot-library/src/main/c_interop/godot.def
+++ b/wrapper/godot-library/src/main/c_interop/godot.def
@@ -2311,7 +2311,7 @@ void godot_string_new_with_wide_string(godot_string * r_dest, const wchar_t * p_
        return api->godot_string_new_with_wide_string(r_dest, p_contents, p_size);
 }
 
-wchar_t * godot_string_operator_index(godot_string * p_self, const godot_int p_idx) {
+const wchar_t * godot_string_operator_index(godot_string * p_self, const godot_int p_idx) {
        return api->godot_string_operator_index(p_self, p_idx);
 }
 

--- a/wrapper/godot-library/src/main/kotlin/godot/core/GDArray.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/GDArray.kt
@@ -176,16 +176,31 @@ class GDArray: CoreType { // FIXME: .copy
         godot_array_sort_custom(nativeValue, obj.getRawMemory(memScope), func.toGDString())
     }
 
+    fun bsearch(value: Variant, before: Boolean): Int = godot_array_bsearch(nativeValue, value.nativeValue, before)
+
+    fun bsearchCustom(value: Variant, obj: Object, func: String, before: Boolean): Int = memScoped {
+        godot_array_bsearch_custom(nativeValue, value.nativeValue, obj.getRawMemory(memScope), func.toGDString(), before)
+    }
+
+    fun duplicate(deep: Boolean) = GDArray(godot_array_duplicate(nativeValue, deep))
+
+    fun max() = Variant(godot_array_max(nativeValue))
+
+    fun min() = Variant(godot_array_min(nativeValue))
+
+    fun shuffle() {
+        godot_array_shuffle(nativeValue)
+    }
 
     override fun equals(other: Any?): Boolean {
-        if (this === other)
-            return true
-        if (other !is GDArray)
-            return false
+        if (this === other) return true
+
+        if (other !is GDArray) return false
+
         return this.hashCode() == other.hashCode()
     }
 }
 
-
 fun Array<*>.toGDArray(): GDArray = GDArray(this)
+
 fun godotArrayOf(vararg params: Any?): GDArray = GDArray(params)

--- a/wrapper/godot-library/src/main/kotlin/godot/core/NodePath.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/NodePath.kt
@@ -50,6 +50,10 @@ class NodePath : CoreType {
 
     fun isEmpty(): Boolean = godot_node_path_is_empty(nativeValue)
 
+    fun getAsPropertyPath() = NodePath(godot_node_path_get_as_property_path(nativeValue))
+
+    fun getConcatenatedSubnames() = godot_node_path_get_concatenated_subnames(nativeValue).toKString()
+
     override fun equals(other: Any?): Boolean =
         if(other is NodePath) godot_node_path_operator_equal(nativeValue, other.nativeValue)
         else false
@@ -57,6 +61,4 @@ class NodePath : CoreType {
     override fun hashCode(): Int {
         return nativeValue.hashCode()
     }
-
-
 }

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Quat.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Quat.kt
@@ -191,11 +191,11 @@ class Quat: CoreType {
         w /= this.length()
     }
 
-    fun normalized(): Quat =
-            this / this.length()
+    fun normalized(): Quat = this / this.length()
 
-    fun inverse(): Quat =
-            Quat(-x, -y, -z, -w)
+    fun inverse(): Quat = Quat(-x, -y, -z, -w)
+
+    fun isNormalized() = abs(lengthSquared() - 1.0) < 0.00001
 
     fun slerp(q: Quat, t: Double): Quat {
         val to1 = Quat()
@@ -265,11 +265,9 @@ class Quat: CoreType {
         return sp.slerpni(sq, t2)
     }
 
-    fun getAxis(): Vector3
-            = Vector3(x / sqrt(1.0 - w*w), y / sqrt(1.0 - w*w),z / sqrt(1.0 - w*w))
+    fun getAxis(): Vector3 = Vector3(x / sqrt(1.0 - w*w), y / sqrt(1.0 - w*w),z / sqrt(1.0 - w*w))
 
-    fun getAngle(): Double
-            = 2 * acos(w)
+    fun getAngle(): Double = 2 * acos(w)
 
     operator fun times(v: Vector3) =
             Quat( w * v.x + y * v.z - z * v.y,

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Rect2.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Rect2.kt
@@ -8,19 +8,19 @@ import kotlin.math.min
 
 
 class Rect2: CoreType {
-    var pos = Vector2()
+    var position = Vector2()
     var size = Vector2()
 
 
     constructor()
 
     constructor(x: Number, y: Number, width: Number, height: Number) {
-        pos = Vector2(x, y)
+        position = Vector2(x, y)
         size = Vector2(width, height)
     }
 
     constructor(pos: Vector2, size: Vector2) {
-        this.pos = pos
+        this.position = pos
         this.size = size
     }
 
@@ -36,12 +36,12 @@ class Rect2: CoreType {
 
 
     override fun getRawMemory(memScope: MemScope): COpaquePointer {
-        return cValuesOf(pos[0].toFloat(), pos[1].toFloat(), size[0].toFloat(), size[1].toFloat()).getPointer(memScope)
+        return cValuesOf(position[0].toFloat(), position[1].toFloat(), size[0].toFloat(), size[1].toFloat()).getPointer(memScope)
     }
     override fun setRawMemory(mem: COpaquePointer) {
         val arr = mem.reinterpret<FloatVar>()
-        pos[0] = arr[0].toDouble()
-        pos[1] = arr[1].toDouble()
+        position[0] = arr[0].toDouble()
+        position[1] = arr[1].toDouble()
         size[0] = arr[2].toDouble()
         size[1] = arr[3].toDouble()
     }
@@ -52,27 +52,27 @@ class Rect2: CoreType {
 
     fun intersects(rect: Rect2): Boolean =
             when {
-                pos.x >= (rect.pos.x + rect.size.width) -> false
-                (pos.x+size.width) <= rect.pos.x          -> false
-                pos.y >= (rect.pos.y + rect.size.height)-> false
-                (pos.y+size.height) <= rect.pos.y         -> false
+                position.x >= (rect.position.x + rect.size.width) -> false
+                (position.x+size.width) <= rect.position.x          -> false
+                position.y >= (rect.position.y + rect.size.height)-> false
+                (position.y+size.height) <= rect.position.y         -> false
                 else                                        ->  true
             }
 
     fun encloses(rect: Rect2): Boolean =
-            (rect.pos.x>=pos.x) && (rect.pos.y>=pos.y) &&
-                    ((rect.pos.x+rect.size.x)<(pos.x+size.x)) &&
-                    ((rect.pos.y+rect.size.y)<(pos.y+size.y))
+            (rect.position.x>=position.x) && (rect.position.y>=position.y) &&
+                    ((rect.position.x+rect.size.x)<(position.x+size.x)) &&
+                    ((rect.position.y+rect.size.y)<(position.y+size.y))
 
     fun hasNoArea(): Boolean =
             size.x<=0 || size.y<=0
 
     fun hasPoint(point: Vector2): Boolean =
             when {
-                point.x < pos.x           -> false
-                point.y < pos.y           -> false
-                point.x >= (pos.x+size.x) -> false
-                point.y >= (pos.y+size.y) -> false
+                point.x < position.x           -> false
+                point.y < position.y           -> false
+                point.x >= (position.x+size.x) -> false
+                point.y >= (position.y+size.y) -> false
                 else                        -> true
             }
 
@@ -81,14 +81,14 @@ class Rect2: CoreType {
 
     override fun equals(other: Any?): Boolean =
             when (other) {
-                is Rect2 -> pos==other.pos && size==other.size
+                is Rect2 -> position==other.position && size==other.size
                 else     -> false
             }
 
     fun grow(by: Double): Rect2 {
         val g = this
-        g.pos.x -= by
-        g.pos.y -= by
+        g.position.x -= by
+        g.position.y -= by
         g.size.width += by * 2
         g.size.height += by * 2
         return g
@@ -101,8 +101,8 @@ class Rect2: CoreType {
     }
 
     fun expandTo(vector: Vector2) {
-        val begin = pos
-        val end = pos + size
+        val begin = position
+        val end = position + size
 
         if (vector.x < begin.x)
             begin.x = vector.x
@@ -114,24 +114,24 @@ class Rect2: CoreType {
         if (vector.y > end.y)
             end.y = vector.y
 
-        pos = begin
+        position = begin
         size = end-begin
     }
 
 
     fun distanceTo(point: Vector2): Double {
         var dist = 1e20
-        if (point.x < pos.x) {
-            dist = min(dist,pos.x-point.x)
+        if (point.x < position.x) {
+            dist = min(dist,position.x-point.x)
         }
-        if (point.y < pos.y) {
-            dist = min(dist,pos.y-point.y)
+        if (point.y < position.y) {
+            dist = min(dist,position.y-point.y)
         }
-        if (point.x >= (pos.x+size.x) ) {
-            dist= min(point.x-(pos.x+size.x),dist)
+        if (point.x >= (position.x+size.x) ) {
+            dist= min(point.x-(position.x+size.x),dist)
         }
-        if (point.y >= (pos.y+size.y) ) {
-            dist= min(point.y-(pos.y+size.y),dist)
+        if (point.y >= (position.y+size.y) ) {
+            dist= min(point.y-(position.y+size.y),dist)
         }
         return if (dist==1e20)
             0.0
@@ -140,37 +140,35 @@ class Rect2: CoreType {
     }
 
     fun clip(rect: Rect2): Rect2 {
-        if (!intersects(rect))
-            return Rect2()
+        if (!intersects(rect)) return Rect2()
 
-        rect.pos.x = max( rect.pos.x , pos.x )
-        rect.pos.y = max( rect.pos.y , pos.y )
+        rect.position.x = max( rect.position.x , position.x )
+        rect.position.y = max( rect.position.y , position.y )
 
-        val rectEnd = rect.pos+rect.size
-        val end = pos+size
+        val rectEnd = rect.position+rect.size
+        val end = position+size
 
-        rect.size.x = min(rectEnd.x,end.x) - rect.pos.x
-        rect.size.y = min(rectEnd.y,end.y) - rect.pos.y
+        rect.size.x = min(rectEnd.x,end.x) - rect.position.x
+        rect.size.y = min(rectEnd.y,end.y) - rect.position.y
 
         return rect
     }
 
     fun merge(rect: Rect2): Rect2 {
 
-        rect.pos.x= min( rect.pos.x , pos.x )
-        rect.pos.y= min( rect.pos.y , pos.y )
+        rect.position.x= min( rect.position.x , position.x )
+        rect.position.y= min( rect.position.y , position.y )
 
 
-        rect.size.x = max( rect.pos.x+rect.size.x , pos.x+size.x )
-        rect.size.y = max( rect.pos.y+rect.size.y , pos.y+size.y )
+        rect.size.x = max( rect.position.x+rect.size.x , position.x+size.x )
+        rect.size.y = max( rect.position.y+rect.size.y , position.y+size.y )
 
-        rect.size = rect.size - rect.pos //make relative again
+        rect.size = rect.size - rect.position //make relative again
 
         return rect
     }
 
-    override fun toString(): String =
-            pos.toString() + ", " + size.toString()
+    override fun toString(): String = "$position, $size"
 
     fun intersectsSegment(from: Vector2, to: Vector2, boolPos: Boolean, boolNormal: Boolean): Triple<Boolean, Vector2?, Vector2?> {
         var min = 0.0
@@ -181,7 +179,7 @@ class Rect2: CoreType {
         for (i in 0..1) {
             val segFrom = from[i]
             val segTo = to[i]
-            val boxBegin = pos[i]
+            val boxBegin = position[i]
             val boxEnd = boxBegin + size[i]
             val cmin: Double
             val cmax: Double
@@ -229,18 +227,18 @@ class Rect2: CoreType {
     }
 
     fun intersectsTransformed(xform: Transform2D, rect: Rect2): Boolean {
-        val xfPoints = arrayOf(xform.xform(rect.pos),
-                xform.xform(Vector2(rect.pos.x+rect.size.x,rect.pos.y)),
-                xform.xform(Vector2(rect.pos.x,rect.pos.y+rect.size.y)),
-                xform.xform(Vector2(rect.pos.x+rect.size.x,rect.pos.y+rect.size.y)))
+        val xfPoints = arrayOf(xform.xform(rect.position),
+                xform.xform(Vector2(rect.position.x+rect.size.x,rect.position.y)),
+                xform.xform(Vector2(rect.position.x,rect.position.y+rect.size.y)),
+                xform.xform(Vector2(rect.position.x+rect.size.x,rect.position.y+rect.size.y)))
 
-        var lowLimit = pos.y+size.y
+        var lowLimit = position.y+size.y
 
         when {
-            xfPoints[0].y > pos.y -> {}
-            xfPoints[1].y > pos.y -> {}
-            xfPoints[2].y > pos.y -> {}
-            xfPoints[3].y > pos.y -> {}
+            xfPoints[0].y > position.y -> {}
+            xfPoints[1].y > position.y -> {}
+            xfPoints[2].y > position.y -> {}
+            xfPoints[3].y > position.y -> {}
             else -> return false
         }
 
@@ -253,14 +251,14 @@ class Rect2: CoreType {
         }
 
         when {
-            xfPoints[0].x > pos.x -> {}
-            xfPoints[1].x > pos.x -> {}
-            xfPoints[2].x > pos.x -> {}
-            xfPoints[3].x > pos.x -> {}
+            xfPoints[0].x > position.x -> {}
+            xfPoints[1].x > position.x -> {}
+            xfPoints[2].x > position.x -> {}
+            xfPoints[3].x > position.x -> {}
             else -> return false
         }
 
-        lowLimit = pos.x + size.x
+        lowLimit = position.x + size.x
 
         when {
             xfPoints[0].x < lowLimit -> {}
@@ -270,17 +268,17 @@ class Rect2: CoreType {
             else -> return false
         }
 
-        val xfPoints2 = arrayOf(pos,
-                Vector2(pos.x+size.x,pos.y),
-                Vector2(pos.x,pos.y+size.y),
-                Vector2(pos.x+size.x,pos.y+size.y))
+        val xfPoints2 = arrayOf(position,
+                Vector2(position.x+size.x,position.y),
+                Vector2(position.x,position.y+size.y),
+                Vector2(position.x+size.x,position.y+size.y))
 
         var maxa = xform.elements[0].dot(xfPoints2[0])
         var mina = maxa
 
         var dp = xform.elements[0].dot(xfPoints2[1])
-        maxa= max(dp,maxa)
-        mina= min(dp,mina)
+        maxa = max(dp, maxa)
+        mina = min(dp, mina)
 
         dp = xform.elements[0].dot(xfPoints2[2])
         maxa= max(dp,maxa)
@@ -346,7 +344,7 @@ class Rect2: CoreType {
     }
 
     override fun hashCode(): Int {
-        var result = pos.hashCode()
+        var result = position.hashCode()
         result = 31 * result + size.hashCode()
         return result
     }

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Transform.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Transform.kt
@@ -83,16 +83,16 @@ class Transform: CoreType {
     }
 
     fun xform(vector: Vector3): Vector3 =
-            Vector3(basis[0].dot(vector)+origin.x,
-                    basis[1].dot(vector)+origin.y,
-                    basis[2].dot(vector)+origin.z)
+            Vector3(basis[0].dot(vector) + origin.x,
+                    basis[1].dot(vector) + origin.y,
+                    basis[2].dot(vector) + origin.z)
 
     fun xformInv(vector: Vector3): Vector3 {
         val v = vector - origin
         return Vector3(
-                (basis[0][0]*v.x ) + ( basis[1][0]*v.y ) + ( basis[2][0]*v.z ),
-                (basis[0][1]*v.x ) + ( basis[1][1]*v.y ) + ( basis[2][1]*v.z ),
-                (basis[0][2]*v.x ) + ( basis[1][2]*v.y ) + ( basis[2][2]*v.z )
+                (basis[0][0] * v.x ) + ( basis[1][0] * v.y ) + ( basis[2][0] * v.z ),
+                (basis[0][1] * v.x ) + ( basis[1][1] * v.y ) + ( basis[2][1] * v.z ),
+                (basis[0][2] * v.x ) + ( basis[1][2] * v.y ) + ( basis[2][2] * v.z )
         )
     }
 
@@ -105,7 +105,7 @@ class Transform: CoreType {
         val normal = pointDir - point
         normal.normalize()
 
-        return Plane( normal, normal.dot(point) )
+        return Plane(normal, normal.dot(point))
     }
 
     fun xformInv(plane: Plane): Plane {
@@ -117,14 +117,14 @@ class Transform: CoreType {
         val normal = pointDir - point
         normal.normalize()
 
-        return Plane( normal, normal.dot(point) )
+        return Plane(normal, normal.dot(point))
     }
 
     fun xform(aabb: AABB): AABB {
         val x = basis.getAxis(0) * aabb.size.x
         val y = basis.getAxis(1) * aabb.size.y
         val z = basis.getAxis(2) * aabb.size.z
-        val pos = xform( aabb.position )
+        val pos = xform(aabb.position)
 
         val newAabb = AABB()
         newAabb.position = pos
@@ -140,14 +140,14 @@ class Transform: CoreType {
 
     fun xformInv(aabb: AABB): AABB {
         val vertices: Array<Vector3> =
-                arrayOf(Vector3(aabb.position.x+aabb.size.x,	aabb.position.y+aabb.size.y,	aabb.position.z+aabb.size.z),
-                        Vector3(aabb.position.x+aabb.size.x,	aabb.position.y+aabb.size.y,	aabb.position.z),
-                        Vector3(aabb.position.x+aabb.size.x,	aabb.position.y,		aabb.position.z+aabb.size.z),
-                        Vector3(aabb.position.x+aabb.size.x,	aabb.position.y,		aabb.position.z),
-                        Vector3(aabb.position.x,	aabb.position.y+aabb.size.y,	aabb.position.z+aabb.size.z),
-                        Vector3(aabb.position.x,	aabb.position.y+aabb.size.y,	aabb.position.z),
-                        Vector3(aabb.position.x,	aabb.position.y,		aabb.position.z+aabb.size.z),
-                        Vector3(aabb.position.x,	aabb.position.y,		aabb.position.z))
+                arrayOf(Vector3(aabb.position.x + aabb.size.x, aabb.position.y + aabb.size.y, aabb.position.z + aabb.size.z),
+                        Vector3(aabb.position.x + aabb.size.x, aabb.position.y + aabb.size.y, aabb.position.z),
+                        Vector3(aabb.position.x + aabb.size.x, aabb.position.y, aabb.position.z + aabb.size.z),
+                        Vector3(aabb.position.x + aabb.size.x, aabb.position.y, aabb.position.z),
+                        Vector3(aabb.position.x, aabb.position.y + aabb.size.y, aabb.position.z + aabb.size.z),
+                        Vector3(aabb.position.x, aabb.position.y + aabb.size.y, aabb.position.z),
+                        Vector3(aabb.position.x, aabb.position.y, aabb.position.z + aabb.size.z),
+                        Vector3(aabb.position.x, aabb.position.y, aabb.position.z))
 
         val ret = AABB()
         ret.position = xformInv(vertices[0])
@@ -185,8 +185,7 @@ class Transform: CoreType {
         this.origin = t.origin
     }
 
-    fun rotated(axis: Vector3, phi: Double): Transform =
-            Transform(Basis( axis, phi ), Vector3()) * this
+    fun rotated(axis: Vector3, phi: Double): Transform = Transform(Basis(axis, phi), Vector3()) * this
 
     fun rotateBasis(axis: Vector3, phi: Double) {
         basis.rotate(axis, phi)
@@ -248,12 +247,10 @@ class Transform: CoreType {
     }
 
     fun translate(translation: Vector3) {
-        for (i in 0..2)
-            origin[i] += basis[i].dot(translation)
+        for (i in 0..2) origin[i] += basis[i].dot(translation)
     }
 
-    fun translate(tx: Double, ty: Double, tz: Double) =
-            translate(Vector3(tx, ty, tz))
+    fun translate(tx: Double, ty: Double, tz: Double) = translate(Vector3(tx, ty, tz))
 
     fun translated(translation: Vector3): Transform {
         val t = this
@@ -261,8 +258,7 @@ class Transform: CoreType {
         return t
     }
 
-    fun orthonormalize() =
-            basis.orthonormalize()
+    fun orthonormalize() = basis.orthonormalize()
 
     fun orthonormalized(): Transform {
         val t = this
@@ -284,9 +280,7 @@ class Transform: CoreType {
         return t
     }
 
-    override fun toString(): String {
-        return basis.toString() + " - " + origin.toString()
-    }
+    override fun toString(): String = "$basis - $origin"
 
     override fun hashCode(): Int {
         var result = basis.hashCode()

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Transform2D.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Transform2D.kt
@@ -116,10 +116,10 @@ class Transform2D: CoreType {
     fun xform(rect: Rect2): Rect2 {
         val x = elements[0] * rect.size.x
         val y = elements[1] * rect.size.y
-        val pos = xform(rect.pos)
+        val pos = xform(rect.position)
 
         val newRect = Rect2()
-        newRect.pos = pos
+        newRect.position = pos
         newRect.expandTo(pos + x)
         newRect.expandTo(pos + y)
         newRect.expandTo(pos + x + y)
@@ -134,13 +134,13 @@ class Transform2D: CoreType {
     }
 
     fun xformInv(rect: Rect2): Rect2 {
-        val ends = arrayOf(xformInv(rect.pos),
-                xformInv(Vector2(rect.pos.x, rect.pos.y + rect.size.y)),
-                xformInv(Vector2(rect.pos.x + rect.size.x, rect.pos.y + rect.size.y)),
-                xformInv(Vector2(rect.pos.x + rect.size.x, rect.pos.y)))
+        val ends = arrayOf(xformInv(rect.position),
+                xformInv(Vector2(rect.position.x, rect.position.y + rect.size.y)),
+                xformInv(Vector2(rect.position.x + rect.size.x, rect.position.y + rect.size.y)),
+                xformInv(Vector2(rect.position.x + rect.size.x, rect.position.y)))
 
         val newRect = Rect2()
-        newRect.pos=ends[0]
+        newRect.position=ends[0]
         newRect.expandTo(ends[1])
         newRect.expandTo(ends[2])
         newRect.expandTo(ends[3])

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Transform2D.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Transform2D.kt
@@ -76,37 +76,29 @@ class Transform2D: CoreType {
 
 
 
-    fun tdotx(v: Vector2): Double =
-            elements[0][0] * v.x + elements[1][0] * v.y
+    fun tdotx(v: Vector2) = elements[0][0] * v.x + elements[1][0] * v.y
 
-    fun tdoty(v: Vector2): Double =
-            elements[0][1] * v.x + elements[1][1] * v.y
+    fun tdoty(v: Vector2) = elements[0][1] * v.x + elements[1][1] * v.y
 
-    operator fun get(n: Int): Vector2 =
-            elements[n]
+    operator fun get(n: Int) = elements[n]
 
-    fun getAxis(axis: Int) =
-            elements[axis]
+    fun getAxis(axis: Int) = elements[axis]
 
     fun setAxis(axis: Int, vec: Vector2) {
         elements[axis] = vec
     }
 
-    fun getOrigin(): Vector2 =
-            elements[2]
+    fun getOrigin() = elements[2]
 
     fun setOrigin(origin: Vector2) {
         elements[2] = origin
     }
 
-    fun basisXform(v: Vector2): Vector2 =
-            Vector2(tdotx(v), tdoty(v))
+    fun basisXform(v: Vector2) = Vector2(tdotx(v), tdoty(v))
 
-    fun basisXformInv(v: Vector2): Vector2 =
-            Vector2(elements[0].dot(v), elements[1].dot(v))
+    fun basisXformInv(v: Vector2) = Vector2(elements[0].dot(v), elements[1].dot(v))
 
-    fun xform(v: Vector2): Vector2 =
-            Vector2(tdotx(v), tdoty(v)) + elements[2]
+    fun xform(v: Vector2) = Vector2(tdotx(v), tdoty(v)) + elements[2]
 
     fun xformInv(vec: Vector2): Vector2 {
         val v = vec - elements[2]
@@ -127,10 +119,10 @@ class Transform2D: CoreType {
     }
 
     fun setRotationAndScale(rot: Double, scale: Vector2) {
-        elements[0][0]=cos(rot)*scale.x
-        elements[1][1]=cos(rot)*scale.y
-        elements[1][0]=-sin(rot)*scale.y
-        elements[0][1]=sin(rot)*scale.x
+        elements[0][0] = cos(rot) * scale.x
+        elements[1][1] = cos(rot) * scale.y
+        elements[1][0] = -sin(rot) * scale.y
+        elements[0][1] = sin(rot) * scale.x
     }
 
     fun xformInv(rect: Rect2): Rect2 {
@@ -333,8 +325,7 @@ class Transform2D: CoreType {
     }
 
 
-    override fun toString(): String =
-            elements[0].toString() + ", " + elements[1].toString() + ", " + elements[2]
+    override fun toString() = "${elements[0]}, ${elements[1]}, ${elements[2]}"
 
     override fun hashCode(): Int = this.toString().hashCode()
 }

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Variant.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Variant.kt
@@ -15,29 +15,29 @@ class Variant: CoreType { // FIXME: redundant .copy
         REAL(3),
         STRING(4),
 
-        VECTOR2(5),        // 5
+        VECTOR2(5), // 5
         RECT2(6),
         VECTOR3(7),
         TRANSFORM2D(8),
         PLANE(9),
-        QUAT(10),            // 10
+        QUAT(10), // 10
         RECT3(11),
         BASIS(12),
         TRANSFORM(13),
 
         COLOR(14),
-        NODE_PATH(15),              // 15
+        NODE_PATH(15), // 15
         _RID(16),
         OBJECT(17),
         DICTIONARY(18),
         ARRAY(19),
 
-        POOL_BYTE_ARRAY(20),        // 20
+        POOL_BYTE_ARRAY(20), // 20
         POOL_INT_ARRAY(21),
         POOL_REAL_ARRAY(22),
         POOL_STRING_ARRAY(23),
         POOL_VECTOR2_ARRAY(24),
-        POOL_VECTOR3_ARRAY(25),     // 25
+        POOL_VECTOR3_ARRAY(25), // 25
         POOL_COLOR_ARRAY(26),
 
         VARIANT_MAX(27);
@@ -358,7 +358,7 @@ class Variant: CoreType { // FIXME: redundant .copy
 
     fun toTransform2D(): Transform2D = Transform2D(godot_variant_as_transform2d(nativeValue))
 
-    fun getType(): Variant.Type = Type.fromInt(godot_variant_get_type(nativeValue).value.toLong())
+    fun getType(): Type = Type.fromInt(godot_variant_get_type(nativeValue).value.toLong())
 
     fun call(str: String, args: Array<Variant> = arrayOf()): Variant {
         memScoped {

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Variant.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Variant.kt
@@ -242,9 +242,13 @@ class Variant: CoreType { // FIXME: redundant .copy
         }
     }
 
-    constructor(other: Object) {
+    constructor(other: Object?) {
         memScoped {
-            nativeValue = nativeValue.copy { godot_variant_new_object(this.ptr, other.getRawMemory(memScope)) }
+            nativeValue = if (other != null) {
+                nativeValue.copy { godot_variant_new_object(this.ptr, other.getRawMemory(memScope)) }
+            } else {
+                nativeValue.copy { godot_variant_new_nil(this.ptr) }
+            }
         }
     }
 

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
@@ -7,6 +7,21 @@ import kotlin.math.*
 
 
 class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
+
+    enum class Axis(private val value: Int) {
+        X(0),
+        Y(1);
+
+        companion object {
+            fun from(value: Int): Axis {
+                values().forEach {
+                    if (it.value == value) return it
+                }
+                throw AssertionError("$value is not a valid value for Enum Vector2.Axis")
+            }
+        }
+    }
+
     constructor() :
             this(0.0, 0.0)
 

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
@@ -8,6 +8,15 @@ import kotlin.math.*
 
 class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
 
+    companion object {
+        fun linearInterpolate(vector1: Vector2, vector2: Vector2, t: Double): Vector2 {
+            val res: Vector2 = vector1
+            res.x += (t * (vector2.x - vector1.x))
+            res.y += (t * (vector2.y - vector1.y))
+            return res
+        }
+    }
+
     enum class Axis(private val value: Int) {
         X(0),
         Y(1);
@@ -134,32 +143,23 @@ class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
         return v
     }
 
-    fun length(): Double =
-            sqrt(x * x + y * y)
+    fun length() = sqrt(x * x + y * y)
 
-    fun lengthSquared(): Double =
-            x * x + y * y
+    fun lengthSquared() = x * x + y * y
 
-    fun distanceTo(vector2: Vector2): Double =
-            sqrt((x - vector2.x) * (x - vector2.x) + (y - vector2.y) * (y - vector2.y))
+    fun distanceTo(vector2: Vector2) = sqrt((x - vector2.x) * (x - vector2.x) + (y - vector2.y) * (y - vector2.y))
 
-    fun distanceSquaredTo(vector2: Vector2): Double =
-            (x - vector2.x) * (x - vector2.x) + (y - vector2.y) * (y - vector2.y)
+    fun distanceSquaredTo(vector2: Vector2) = (x - vector2.x) * (x - vector2.x) + (y - vector2.y) * (y - vector2.y)
 
-    fun angleTo(vector2: Vector2): Double =
-            atan2(cross(vector2), dot(vector2))
+    fun angleTo(vector2: Vector2) = atan2(cross(vector2), dot(vector2))
 
-    fun angleToPoint(vector2: Vector2): Double =
-            atan2(y - vector2.y, x - vector2.x)
+    fun angleToPoint(vector2: Vector2) = atan2(y - vector2.y, x - vector2.x)
 
-    fun dot(other: Vector2): Double =
-            x * other.x + y * other.y
+    fun dot(other: Vector2) = x * other.x + y * other.y
 
-    fun cross(other: Vector2): Double =
-            x * other.y - y * other.x
+    fun cross(other: Vector2) = x * other.y - y * other.x
 
-    fun cross(other: Double): Vector2 =
-            Vector2(other * y, -other * x)
+    fun cross(other: Double) = Vector2(other * y, -other * x)
 
     fun project(vec: Vector2): Vector2 {
         val v1: Vector2 = vec
@@ -202,31 +202,20 @@ class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
                 (-p0 + p1 * 3.0 - p2 * 3.0 + p3) * t3) * 0.5
     }
 
-    fun slide(vec: Vector2): Vector2 =
-            this - vec * this.dot(vec)
+    fun slide(vec: Vector2) = vec - this * this.dot(vec)
 
-    fun reflect(vec: Vector2): Vector2 {
-//        val vecSub = vec
-//        vecSub.y = -vecSub.y
-        return vec * this.dot(vec) * 2.0 - this
-        //0,1
-        //100,300
-        // -> 100,-300
-    }
+    fun reflect(vec: Vector2) = vec - this * this.dot(vec) * 2.0
 
-    fun bounce(vec: Vector2): Vector2 =
-    		-reflect(vec)
+    fun bounce(vec: Vector2) = -reflect(vec)
 
-    fun angle(): Double =
-            atan2(y, x)
+    fun angle() = atan2(y, x)
 
     fun setRotation(radians: Double) {
         x = cos(radians)
         y = sin(radians)
     }
 
-    fun abs(): Vector2 =
-            Vector2(kotlin.math.abs(x), kotlin.math.abs(y))
+    fun abs() = Vector2(abs(x), abs(y))
 
     fun rotated(by: Double): Vector2 {
         var v = Vector2(0.0, 0.0)
@@ -235,25 +224,19 @@ class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
         return v
     }
 
-    fun tangent(): Vector2 =
-            Vector2(y, -x)
+    fun tangent() = Vector2(y, -x)
 
-    fun floor(): Vector2 =
-            Vector2(kotlin.math.floor(x), kotlin.math.floor(y))
+    fun floor() = Vector2(floor(x), floor(y))
 
     fun snapped(by: Vector2): Vector2 {
-        val newx: Double = if (by.x != 0.0)
-            kotlin.math.floor(x / by.x + 0.5)
-        else x
-        val newy = if (by.y != 0.0)
-            kotlin.math.floor(y / by.y + 0.5)
-        else y
+        val newX: Double = if (by.x != 0.0) floor(x / by.x + 0.5) else x
 
-        return Vector2(newx, newy)
+        val newY = if (by.y != 0.0) floor(y / by.y + 0.5) else y
+
+        return Vector2(newX, newY)
     }
 
-    fun aspect(): Double =
-            this.width / this.height
+    fun aspect()= this.width / this.height
 
 
 
@@ -261,5 +244,4 @@ class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
     override fun hashCode(): Int = this.toString().hashCode()
 }
 
-operator fun Double.times(vec: Vector2): Vector2 =
-        vec * this
+operator fun Double.times(vec: Vector2) = vec * this

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Vector2.kt
@@ -204,7 +204,7 @@ class Vector2(var x: Double, var y: Double) : Comparable<Vector2>, CoreType {
 
     fun slide(vec: Vector2) = vec - this * this.dot(vec)
 
-    fun reflect(vec: Vector2) = vec - this * this.dot(vec) * 2.0
+    fun reflect(vec: Vector2) = vec * this.dot(vec) * 2.0 - this
 
     fun bounce(vec: Vector2) = -reflect(vec)
 

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Vector3.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Vector3.kt
@@ -45,8 +45,6 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
         z = arr[2].toDouble()
     }
 
-
-
     operator fun get(n: Int): Double =
             when (n) {
                 0 -> x
@@ -141,26 +139,21 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
                 (-p0 + p1 * 3.0 - p2 * 3.0 + p3) * t3) * 0.5
     }
 
-    fun length(): Double =
-            sqrt(x * x + y * y + z * z)
+    fun length(): Double = sqrt(x * x + y * y + z * z)
 
-    fun lengthSquared(): Double =
-            x * x + y * y + z * z
+    fun lengthSquared(): Double = x * x + y * y + z * z
 
-    fun distanceSquaredTo(b: Vector3): Double =
-            (b - this).length()
+    fun distanceSquaredTo(b: Vector3): Double = (b - this).length()
 
-    fun distanceTo(b: Vector3): Double =
-            (b - this).lengthSquared()
+    fun distanceTo(b: Vector3): Double = (b - this).lengthSquared()
 
-    fun dot(b: Vector3): Double =
-            x * b.x + y * b.y + z * b.z
+    fun dot(b: Vector3): Double = x * b.x + y * b.y + z * b.z
 
-    fun floor(): Vector3 =
-            Vector3(kotlin.math.floor(x), kotlin.math.floor(y), kotlin.math.floor(z))
+    fun floor(): Vector3 = Vector3(kotlin.math.floor(x), kotlin.math.floor(y), kotlin.math.floor(z))
 
-    fun inverse(): Vector3 =
-            Vector3(1.0 / x, 1.0 / y, 1.0 / z)
+    fun inverse(): Vector3 = Vector3(1.0 / x, 1.0 / y, 1.0 / z)
+
+    fun isNormalized() = kotlin.math.abs(lengthSquared() - 1.0) < 0.00001
 
     fun maxAxis(): Int =
             if (x < y)
@@ -231,7 +224,7 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
     }
 
 
-    override fun toString() = "$x, $y, $z"
+    override fun toString() = "($x, $y, $z)"
     override fun hashCode(): Int = this.toString().hashCode()
 }
 

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Vector3.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Vector3.kt
@@ -108,21 +108,13 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
             }
     }
 
-    fun abs(): Vector3 =
-            Vector3(kotlin.math.abs(x), kotlin.math.abs(y), kotlin.math.abs(z))
+    fun abs(): Vector3 = Vector3(kotlin.math.abs(x), kotlin.math.abs(y), kotlin.math.abs(z))
 
-    fun ceil(): Vector3 =
-            Vector3(kotlin.math.ceil(x), kotlin.math.ceil(y), kotlin.math.ceil(z))
+    fun ceil(): Vector3 = Vector3(kotlin.math.ceil(x), kotlin.math.ceil(y), kotlin.math.ceil(z))
 
-    fun cross(b: Vector3): Vector3 =
-            Vector3((y * b.z) - (z * b.y),
-                    (z * b.x) - (x * b.z),
-                    (x * b.y) - (y * b.x))
+    fun cross(b: Vector3): Vector3 = Vector3((y * b.z) - (z * b.y), (z * b.x) - (x * b.z), (x * b.y) - (y * b.x))
 
-    fun linearInterpolate(b: Vector3, t: Double): Vector3 =
-            Vector3(x + (t * (b.x - x)),
-                    y + (t * (b.y - y)),
-                    z + (t * (b.z - z)))
+    fun linearInterpolate(b: Vector3, t: Double): Vector3 = Vector3(x + (t * (b.x - x)), y + (t * (b.y - y)), z + (t * (b.z - z)))
 
     fun cubicInterpolate(b: Vector3, pre: Vector3, post: Vector3, t: Double): Vector3 {
         val p0: Vector3 = pre
@@ -143,9 +135,9 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
 
     fun lengthSquared(): Double = x * x + y * y + z * z
 
-    fun distanceSquaredTo(b: Vector3): Double = (b - this).length()
+    fun distanceSquaredTo(b: Vector3): Double = (b - this).lengthSquared()
 
-    fun distanceTo(b: Vector3): Double = (b - this).lengthSquared()
+    fun distanceTo(b: Vector3): Double = (b - this).length()
 
     fun dot(b: Vector3): Double = x * b.x + y * b.y + z * b.z
 
@@ -155,21 +147,25 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
 
     fun isNormalized() = kotlin.math.abs(lengthSquared() - 1.0) < 0.00001
 
-    fun maxAxis(): Int =
-            if (x < y)
-                if (y < z) 2
-                else 1
-            else
-                if (x < z) 2
-                else 0
+    fun outer(b: Vector3) = Basis(
+            Vector3(x * b.x, x * b.y, x * b.z),
+            Vector3(y * b.x, y * b.y, y * b.z),
+            Vector3(z * b.x, z * b.y, z * b.z)
+    )
 
-    fun minAxis(): Int =
-            if (x < y)
-                if (x < z) 0
-                else 2
-            else
-                if (y < z) 1
-                else 2
+    fun maxAxis() = if (x < y) {
+        if (y < z) 2 else 1
+    } else {
+        if (x < z) 2 else 0
+    }
+
+    fun minAxis() = if (x < y) {
+        if (x < z) 0
+        else 2
+    } else {
+        if (y < z) 1
+        else 2
+    }
 
     fun normalize() {
         val l: Double = this.length()
@@ -190,8 +186,7 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
         return v
     }
 
-    fun reflect(by: Vector3): Vector3 =
-            by - this * this.dot(by) * 2.0
+    fun reflect(by: Vector3) = by - this * this.dot(by) * 2.0
 
     fun rotated(axis: Vector3, phi: Double): Vector3 {
         val v = this
@@ -206,8 +201,7 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
         this.z = ret.z
     }
 
-    fun slide(by: Vector3): Vector3 =
-            by - this * this.dot(by)
+    fun slide(by: Vector3): Vector3 = by - this * this.dot(by)
 
     fun snap(vecal: Double) {
         if (vecal != 0.0) {
@@ -228,10 +222,8 @@ class Vector3(var x: Double, var y: Double, var z: Double) : Comparable<Vector3>
     override fun hashCode(): Int = this.toString().hashCode()
 }
 
-operator fun Double.times(vecec: Vector3) =
-        vecec * this
+operator fun Double.times(vecec: Vector3) = vecec * this
 
-fun vec3Cross(a: Vector3, b: Vector3): Vector3 =
-        a.cross(b)
+fun vec3Cross(a: Vector3, b: Vector3) = a.cross(b)
 
 

--- a/wrapper/godot-library/src/main/kotlin/godot/registration/Enums.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/registration/Enums.kt
@@ -4,14 +4,15 @@ import godot.gdnative.*
 
 
 enum class RPCMode(val value: godot_method_rpc_mode) {
-    Disabled(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_DISABLED),
-    Remote(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_REMOTE),
-    Sync(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_SYNC),
-    Master(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_MASTER),
-    Slave(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_SLAVE),
-    RemoteSync(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_REMOTESYNC),
-    MasterSync(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_MASTERSYNC),
-    SlaveSync(godot_method_rpc_mode.GODOT_METHOD_RPC_MODE_SLAVESYNC)
+    Disabled(GODOT_METHOD_RPC_MODE_DISABLED),
+    Remote(GODOT_METHOD_RPC_MODE_REMOTE),
+    Sync(GODOT_METHOD_RPC_MODE_SYNC),
+    Master(GODOT_METHOD_RPC_MODE_MASTER),
+    Slave(GODOT_METHOD_RPC_MODE_SLAVE),
+    Puppet(GODOT_METHOD_RPC_MODE_PUPPET),
+    RemoteSync(GODOT_METHOD_RPC_MODE_REMOTESYNC),
+    MasterSync(GODOT_METHOD_RPC_MODE_MASTERSYNC),
+    PuppetSync(GODOT_METHOD_RPC_MODE_PUPPETSYNC)
 }
 
 


### PR DESCRIPTION
This updates bindings for use with godot 3.2.
Update GDNative headers to 3.2
Change core classes for godot 3.2

It seems  memscope mentionned in #1  are not mandatory as we're not using pointers in methods that don't have them.
Methods with no argument could be transformed into a backing field, like `Vector3.normalize`, but this is not the subject of this PR.
Also, we should wait #8 is merged in this branch before merging this one in master.

Please guys review this PR carrefully, as core classes has changed.

This resolves #1 and resolves #9 