### PR TITLE
Add missing plugin repository to samples and getting started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -50,6 +50,7 @@ Inside your `build.gradle.kts` file, you need to define the `godot-gradle-plugin
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -66,6 +67,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 ```
@@ -158,6 +160,7 @@ If you followed along your `build.gradle.kts` file should look like this:
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -174,6 +177,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
         mavenCentral()
     }
@@ -12,6 +13,7 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -17,6 +18,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 


### PR DESCRIPTION
This adds the missing utopia-rise plugin repository to the sample projects and the getting started guide.
This was originally a hotfix for the old repo's base project that we actually never merged into our own master branch.

Without this the getting started guide will not work without building everything locally.
Same for the samples.