### PR TITLE
Add gitter as developer communication channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Look into [**Registration**](./REGISTRATION.md) section to get more information.
 
 Look into [**Compiling from source**](COMPILING_FROM_SOURCE.md) section to get more information.
 
+## Developer discussion
+
+Ask questions and collaborate on Gitter:
+https://gitter.im/Godot-Kotlin/community
+
 ## Authors
 
 All authors are indicated in [*CONTRIBUTORS*](https://github.com/utopia-rise/kotlin-godot-wrapper/graphs/contributors) section on **GitHub**.  


### PR DESCRIPTION
I keep wishing I could shoot you guys some questions without creating a bunch of issues on Github.

So I created a Gitter channel thinking that might be a useful real time communication channel.

I added it to the README so people can find it. @piiertho @chippmann ect, I can make you guys admins on it if you think this is a good idea.

Further, @piiertho could setup the github integration in Gitter if you guys think it'd be useful.

It'd be kinda cool if we could get our own channel in the Godot Discord server, but I'm not sure who to talk to about that.