### PR TITLE
Feature/android support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,9 @@ gradle-app.setting
 
 # End of https://www.gitignore.io/api/gradle
 
+# Mac OS
 
+*.DS_Store
 
 # 
 !samples/project/Kotlin/GodotCMakeModule/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: java
 matrix:
   include:
-    - os: osx
+    - name: MacOS
+      env: PLATFORM=macos
+      os: osx
       osx_image: xcode11.2
-    - os: linux
-    - os: windows
+    - name: Linux
+      env: PLATFORM=linux
+      os: linux
+    - name: Windows
+      env: PLATFORM=windows
+      os: windows
       language: shell
+    - name: Android Arm64
+      env: PLATFORM=android ANDROID_ARCH=arm64
+      os: linux
+    - name: Android x64
+      env: PLATFORM=android ANDROID_ARCH=X64
+      os: linux
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     export JAVA_HOME=${JAVA_HOME:-/c/jdk}
@@ -15,14 +27,13 @@ before_install:
     fi
 install:
   - ./gradlew :tools:api-classes-generator:build
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    ./gradlew :tools:annotations -Pplatform=macos;
-    ./gradlew :wrapper:godot-library:build -Pplatform=macos;
-    ./gradlew :wrapper:godot-library-extension:build -Pplatform=macos;
+  - if [[ "$PLATFORM" == "android" ]]; then
+    ./gradlew :tools:annotations -Pplatform=$PLATFORM -Pandroid_arch=$ANDROID_ARCH;
+    ./gradlew :wrapper:godot-library:build -Pplatform=$PLATFORM -Pandroid_arch=$ANDROID_ARCH;
     else
-    ./gradlew :tools:annotations:build -Pplatform=$TRAVIS_OS_NAME;
-    ./gradlew :wrapper:godot-library:build -Pplatform=$TRAVIS_OS_NAME;
-    ./gradlew :wrapper:godot-library-extension:build -Pplatform=$TRAVIS_OS_NAME;
+    ./gradlew :tools:annotations -Pplatform=$PLATFORM;
+    ./gradlew :wrapper:godot-library:build -Pplatform=$PLATFORM;
+    ./gradlew :wrapper:godot-library-extension:build -Pplatform=$PLATFORM;
     fi
   - ./gradlew :tools:godot-gradle-plugin:build
   - ./gradlew :tools:godot-annotation-processor:build
@@ -30,6 +41,6 @@ install:
   - ./gradlew :tools:kotlin-compiler-native-plugin:build
 deploy:
   - provider: script
-    script: bash .travis/deploy.sh $BINTRAY_USER $BINTRAY_KEY $TRAVIS_OS_NAME
+    script: bash .travis/deploy.sh $BINTRAY_USER $BINTRAY_KEY $PLATFORM $ANDROID_ARCH
     on:
       tags: true

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -14,10 +14,9 @@ if [ $3 == "linux" ]; then
   ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=metadata
 fi
 
-if [ $3 == "osx" ]; then
-  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=macos
-  ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=macos
-  ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=macos
+if [ $3 == "android" ]; then
+  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -Pandroid_arch=$4
+  ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -Pandroid_arch=$4
 else
   ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
   ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3

--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -13,9 +13,9 @@ Use `build` gradle task to automatically build all subprojects. All artifacts wi
 You can also build modules independently in this order:
 ```shell script
 ./gradlew :tools:api-classes-generator:build
-./gradlew :tools:annotations -Pplatform=windows/linux/macos/android; (add -Pandroid_arch=arm64/X64) for android build
-./gradlew :wrapper:godot-library:build -Pplatform=windows/linux/macos/android; (add -Pandroid_arch=arm64/X64) for android build
-./gradlew :wrapper:godot-library-extension:build -Pplatform=windows/linux/macos; Extension is not currently supported on android, we're working on that'
+./gradlew :tools:annotations -Pplatform=windows/linux/macos/android #(add -Pandroid_arch=arm64/X64) for android build
+./gradlew :wrapper:godot-library:build -Pplatform=windows/linux/macos/android #(add -Pandroid_arch=arm64/X64) for android build
+./gradlew :wrapper:godot-library-extension:build -Pplatform=windows/linux/macos #Extension is not currently supported on android, we're working on that'
 ./gradlew :tools:godot-gradle-plugin:build
 ./gradlew :tools:godot-annotation-processor:build
 ./gradlew :tools:kotlin-compiler-plugin:build

--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -9,13 +9,30 @@ git submodule update
 ```
 
 ## Building
-Use `build` gradle task to automatically build all subprojects. All artifacts will be published to your local maven repository.
+Use `build` gradle task to automatically build all subprojects. All artifacts will be published to your local maven repository.  
+You can also build modules independently in this order:
+```shell script
+./gradlew :tools:api-classes-generator:build
+./gradlew :tools:annotations -Pplatform=windows/linux/macos/android; (add -Pandroid_arch=arm64/X64) for android build
+./gradlew :wrapper:godot-library:build -Pplatform=windows/linux/macos/android; (add -Pandroid_arch=arm64/X64) for android build
+./gradlew :wrapper:godot-library-extension:build -Pplatform=windows/linux/macos; Extension is not currently supported on android, we're working on that'
+./gradlew :tools:godot-gradle-plugin:build
+./gradlew :tools:godot-annotation-processor:build
+./gradlew :tools:kotlin-compiler-plugin:build
+./gradlew :tools:kotlin-compiler-native-plugin:build
+```
 
 ## Building the samples
-Per default the samples are not built with the top level `build` gradle task. But you can build them the following ways:
+Samples projects are not included in root gradle project, as it is not the way it works for end user. In order to build samples
+you have to start `build` task from `samples/games/kotlin` directory.
 - Build them manually by directly calling the `build` task of the samples from the IDE or through the commandline:  
-`./gradlew :samples:games:kotlin:build`  
+`cd samples/games/kotlin`  
+`./gradlew build -Pplatform=desired_platform`, `desired_platform` can be either `windows`, `linux`, `macos`, `android`.  
+For android, you have to add `android_arch` parameter like:  
+`./gradlew build -Pplatform=android -Pplatform=X64`, otherwise it will build `arm64` platform by default. Supported target
+are for now `arm64` and `X64`  
 or  
-`./gradlew :samples:coroutines:kotlin:build`
-- Set the property `skipSamplesBuild` to `false` in the [gradle.properties](gradle.properties) file and build using the top level `build` task.
+`cd samples/coroutines/kotlin`
+`./gradlew :samples:coroutines:kotlin:build`  
+Coroutines are not supported on android for now.
  

--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -22,6 +22,11 @@ You can also build modules independently in this order:
 ./gradlew :tools:kotlin-compiler-native-plugin:build
 ```
 
+or you can add the parameter to your `gradle.properties` file if you're supporting only one platform:
+```
+platform=yourplatformgoeshere
+```
+
 ## Building the samples
 Samples projects are not included in root gradle project, as it is not the way it works for end user. In order to build samples
 you have to start `build` task from `samples/games/kotlin` directory.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -63,7 +63,7 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.kotlin.multiplatform") version ("1.3.61")
 }
 
 apply(plugin = "godot-gradle-plugin")

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,4 +1,5 @@
 val platform: String by project
+val android_arch: String by project
 
 buildscript {
     repositories {
@@ -29,13 +30,27 @@ kotlin {
         sourceSets.create("macosMain")
         sourceSets.create("linuxMain")
         sourceSets.create("windowsMain")
-        configure(listOf(sourceSets["macosMain"], sourceSets["linuxMain"], sourceSets["windowsMain"])) {
+        sourceSets.create("androidArm64Main")
+        sourceSets.create("androidX64Main")
+        configure(listOf(
+                sourceSets["macosMain"],
+                sourceSets["linuxMain"],
+                sourceSets["windowsMain"],
+                sourceSets["androidArm64Main"],
+                sourceSets["androidX64Main"]
+        )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
 
 
         configure<org.godotengine.kotlin.gradleplugin.ConfigureGodotConvention> {
-            this.configureGodot(listOf(sourceSets["macosMain"], sourceSets["linuxMain"], sourceSets["windowsMain"])) {
+            this.configureGodot(listOf(
+                    sourceSets["macosMain"],
+                    sourceSets["linuxMain"],
+                    sourceSets["windowsMain"],
+                    sourceSets["androidArm64Main"],
+                    sourceSets["androidX64Main"]
+            )) {
                 sourceSet {
                     kotlin.srcDirs("src/main/kotlin")
                 }
@@ -60,13 +75,22 @@ kotlin {
             "windows" -> listOf(targetFromPreset(presets["godotMingwX64"], "windows"))
             "linux" -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
             "macos" -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
+            "android" -> if (project.hasProperty("android_arch")) {
+                when(android_arch) {
+                    "X64" -> listOf(targetFromPreset(presets["godotAndroidNativeX64"], "androidX64"))
+                    "arm64" -> listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
+                    else -> listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
+                }
+            } else listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
             else -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
         }
     } else {
         listOf(
                 targetFromPreset(presets["godotLinuxX64"], "linux"),
                 targetFromPreset(presets["godotMacosX64"], "macos"),
-                targetFromPreset(presets["godotMingwX64"], "windows")
+                targetFromPreset(presets["godotMingwX64"], "windows"),
+                targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"),
+                targetFromPreset(presets["godotAndroidNativeX64"], "androidX64")
         )
     }
 

--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -18,6 +18,7 @@ version = Dependencies.annotationsVersion
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
+val android_arch: String by project
 
 kotlin {
     if (project.hasProperty("platform")) {
@@ -25,12 +26,21 @@ kotlin {
             "windows" -> mingwX64("windows")
             "linux" -> linuxX64("linux")
             "macos" -> macosX64("macos")
+            "android" -> if (project.hasProperty("android_arch")) {
+                when(android_arch) {
+                    "X64" -> androidNativeX64("androidX64")
+                    "arm64" -> androidNativeArm64("androidArm64")
+                    else -> androidNativeArm64("androidArm64")
+                }
+            } else androidNativeArm64("androidArm64")
             else -> linuxX64("linux")
         }
     } else {
         linuxX64("linux")
         mingwX64("windows")
         macosX64("macos")
+        androidNativeX64("androidX64")
+        androidNativeArm64("androidArm64")
     }
     jvm()
 

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.*
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
+val android_arch: String by project
 
 plugins {
     id("kotlin-multiplatform")
@@ -18,7 +19,15 @@ kotlin {
         sourceSets.create("macosMain")
         sourceSets.create("linuxMain")
         sourceSets.create("windowsMain")
-        configure(listOf(sourceSets["macosMain"], sourceSets["linuxMain"], sourceSets["windowsMain"])) {
+        sourceSets.create("androidArm64Main")
+        sourceSets.create("androidX64Main")
+        configure(listOf(
+                sourceSets["macosMain"],
+                sourceSets["linuxMain"],
+                sourceSets["windowsMain"],
+                sourceSets["androidArm64Main"],
+                sourceSets["androidX64Main"]
+        )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
     }
@@ -29,13 +38,22 @@ kotlin {
                     "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
                     "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                     "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
+                    "android" -> if (project.hasProperty("android_arch")) {
+                        when(android_arch) {
+                            "X64" -> listOf(targetFromPreset(presets["androidNativeX64"], "androidX64"))
+                            "arm64" -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                            else -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                        }
+                    } else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {
                 listOf(
                         targetFromPreset(presets["linuxX64"], "linux"),
                         targetFromPreset(presets["macosX64"], "macos"),
-                        targetFromPreset(presets["mingwX64"], "windows")
+                        targetFromPreset(presets["mingwX64"], "windows"),
+                        targetFromPreset(presets["androidNativeArm64"], "androidArm64"),
+                        targetFromPreset(presets["androidNativeX64"], "androidX64")
                 )
             }
 

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -19,14 +19,10 @@ kotlin {
         sourceSets.create("macosMain")
         sourceSets.create("linuxMain")
         sourceSets.create("windowsMain")
-        sourceSets.create("androidArm64Main")
-        sourceSets.create("androidX64Main")
         configure(listOf(
                 sourceSets["macosMain"],
                 sourceSets["linuxMain"],
-                sourceSets["windowsMain"],
-                sourceSets["androidArm64Main"],
-                sourceSets["androidX64Main"]
+                sourceSets["windowsMain"]
         )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
@@ -38,22 +34,13 @@ kotlin {
                     "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
                     "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                     "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
-                    "android" -> if (project.hasProperty("android_arch")) {
-                        when(android_arch) {
-                            "X64" -> listOf(targetFromPreset(presets["androidNativeX64"], "androidX64"))
-                            "arm64" -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
-                            else -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
-                        }
-                    } else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {
                 listOf(
                         targetFromPreset(presets["linuxX64"], "linux"),
                         targetFromPreset(presets["macosX64"], "macos"),
-                        targetFromPreset(presets["mingwX64"], "windows"),
-                        targetFromPreset(presets["androidNativeArm64"], "androidArm64"),
-                        targetFromPreset(presets["androidNativeX64"], "androidX64")
+                        targetFromPreset(presets["mingwX64"], "windows")
                 )
             }
 

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.*
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
-val android_arch: String by project
 
 plugins {
     id("kotlin-multiplatform")

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
+val android_arch: String by project
 
 group = "org.godotengine.kotlin"
 version = Dependencies.godotLibraryVersion
@@ -18,7 +19,15 @@ kotlin {
         sourceSets.create("macosMain")
         sourceSets.create("linuxMain")
         sourceSets.create("windowsMain")
-        configure(listOf(sourceSets["macosMain"], sourceSets["linuxMain"], sourceSets["windowsMain"])) {
+        sourceSets.create("androidArm64Main")
+        sourceSets.create("androidX64Main")
+        configure(listOf(
+                sourceSets["macosMain"],
+                sourceSets["linuxMain"],
+                sourceSets["windowsMain"],
+                sourceSets["androidArm64Main"],
+                sourceSets["androidX64Main"]
+        )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
     }
@@ -29,13 +38,23 @@ kotlin {
                     "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
                     "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                     "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
+                    "android" -> if (project.hasProperty("android_arch")) {
+                        when(android_arch) {
+                            "X64" -> listOf(targetFromPreset(presets["androidNativeX64"], "androidX64"))
+                            "arm64" -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                            else -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                        }
+                    }
+                    else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {
                 listOf(
                         targetFromPreset(presets["linuxX64"], "linux"),
                         targetFromPreset(presets["macosX64"], "macos"),
-                        targetFromPreset(presets["mingwX64"], "windows")
+                        targetFromPreset(presets["mingwX64"], "windows"),
+                        targetFromPreset(presets["androidNativeArm64"], "androidArm64"),
+                        targetFromPreset(presets["androidNativeX64"], "androidX64")
                 )
             }
 

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -44,8 +44,7 @@ kotlin {
                             "arm64" -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                             else -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                         }
-                    }
-                    else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                    } else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {


### PR DESCRIPTION
This adds support for `android` platform on `arm64` and `X64` targets.

For now we cannot build `godot-library-extension` on android, so there is no `yield` on android for now.

To build on android you have to specify platform and android architecture parameters: 
`-Pplatform=android -Pandroid_arch=arm64`.

I think this is due to the fact that you have to access `Dispatchers.Main` to get exceptions handled, according to this documentation: https://github.com/Kotlin/kotlinx.coroutines#android
I'll write an issue on this repo and on `kotlinx.coroutines` repo, to ask them how to do.
This was tested on arm64 device, One Plus 6.

PS : Font problems on android.