### PR TITLE
Feature/ios support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,19 @@ matrix:
       os: windows
       language: shell
     - name: Android Arm64
-      env: PLATFORM=android ANDROID_ARCH=arm64
+      env: PLATFORM=android ARM_ARCH=arm64
       os: linux
     - name: Android x64
-      env: PLATFORM=android ANDROID_ARCH=X64
+      env: PLATFORM=android ARM_ARCH=X64
       os: linux
+    - name: iOS Arm64
+      env: PLATFORM=ios ARM_ARCH=arm64
+      os: osx
+      osx_image: xcode11.2
+    - name: iOS x64
+      env: PLATFORM=ios ARM_ARCH=X64
+      os: osx
+      osx_image: xcode11.2
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
     export JAVA_HOME=${JAVA_HOME:-/c/jdk}
@@ -27,11 +35,12 @@ before_install:
     fi
 install:
   - ./gradlew :tools:api-classes-generator:build
-  - if [[ "$PLATFORM" == "android" ]]; then
-    ./gradlew :tools:annotations -Pplatform=$PLATFORM -Pandroid_arch=$ANDROID_ARCH;
-    ./gradlew :wrapper:godot-library:build -Pplatform=$PLATFORM -Pandroid_arch=$ANDROID_ARCH;
+  - if [ "$PLATFORM" == "android" ] || [ "$PLATFORM" == "ios" ]; then
+    ./gradlew :tools:annotations:build -Pplatform=$PLATFORM -ParmArch=$ARM_ARCH;
+    ./gradlew :wrapper:godot-library:build -Pplatform=$PLATFORM -ParmArch=$ARM_ARCH;
+    if [ "$PLATFORM" == "ios" ]; then ./gradlew :wrapper:godot-library-extension:build -Pplatform=$PLATFORM -ParmArch=$ARM_ARCH; fi;
     else
-    ./gradlew :tools:annotations -Pplatform=$PLATFORM;
+    ./gradlew :tools:annotations:build -Pplatform=$PLATFORM;
     ./gradlew :wrapper:godot-library:build -Pplatform=$PLATFORM;
     ./gradlew :wrapper:godot-library-extension:build -Pplatform=$PLATFORM;
     fi
@@ -41,6 +50,6 @@ install:
   - ./gradlew :tools:kotlin-compiler-native-plugin:build
 deploy:
   - provider: script
-    script: bash .travis/deploy.sh $BINTRAY_USER $BINTRAY_KEY $PLATFORM $ANDROID_ARCH
+    script: bash .travis/deploy.sh $BINTRAY_USER $BINTRAY_KEY $PLATFORM $ARM_ARCH
     on:
       tags: true

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -14,9 +14,12 @@ if [ $3 == "linux" ]; then
   ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=metadata
 fi
 
-if [ $3 == "android" ]; then
-  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -Pandroid_arch=$4
-  ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -Pandroid_arch=$4
+if [ $3 == "android" || $3 == "ios" ]; then
+  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
+  ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
+  if [ $3 == "ios" ]; then
+      ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
+  fi
 else
   ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
   ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3

--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -13,9 +13,9 @@ Use `build` gradle task to automatically build all subprojects. All artifacts wi
 You can also build modules independently in this order:
 ```shell script
 ./gradlew :tools:api-classes-generator:build
-./gradlew :tools:annotations -Pplatform=windows/linux/macos/android #(add -Pandroid_arch=arm64/X64) for android build
-./gradlew :wrapper:godot-library:build -Pplatform=windows/linux/macos/android #(add -Pandroid_arch=arm64/X64) for android build
-./gradlew :wrapper:godot-library-extension:build -Pplatform=windows/linux/macos #Extension is not currently supported on android, we're working on that'
+./gradlew :tools:annotations -Pplatform=windows/linux/macos/android/ios #(add -ParmArch=arm64/X64) for android and ios build
+./gradlew :wrapper:godot-library:build -Pplatform=windows/linux/macos/android/ios #(add -ParmArch=arm64/X64) for android and ios build
+./gradlew :wrapper:godot-library-extension:build -Pplatform=windows/linux/macos/ios #(add -ParmArch=arm64/X64) for ios build, extension is not currently supported on android, we're working on that
 ./gradlew :tools:godot-gradle-plugin:build
 ./gradlew :tools:godot-annotation-processor:build
 ./gradlew :tools:kotlin-compiler-plugin:build
@@ -32,12 +32,18 @@ Samples projects are not included in root gradle project, as it is not the way i
 you have to start `build` task from `samples/games/kotlin` directory.
 - Build them manually by directly calling the `build` task of the samples from the IDE or through the commandline:  
 `cd samples/games/kotlin`  
-`./gradlew build -Pplatform=desired_platform`, `desired_platform` can be either `windows`, `linux`, `macos`, `android`.  
-For android, you have to add `android_arch` parameter like:  
+`./gradlew build -Pplatform=desired_platform`, `desired_platform` can be either `windows`, `linux`, `macos`, `android`, `ios`.  
+For android and ios, you have to add `armArch` parameter like:  
 `./gradlew build -Pplatform=android -Pplatform=X64`, otherwise it will build `arm64` platform by default. Supported target
 are for now `arm64` and `X64`  
 or  
 `cd samples/coroutines/kotlin`
-`./gradlew :samples:coroutines:kotlin:build`  
+`./gradlew kotlin:build`  
 Coroutines are not supported on android for now.
  
+Also on ios you should add you signing identity, as it is apple requirement, like:
+```shell script
+./gradlew build -Pplatform=ios -ParmArch=arm64 -PiosSigningIdentity="youridentity"
+```
+`youridentity` should looks like this : `Apple Development: mail@provider.com (XXXXXXXXXX)`.
+You can also add `iosSigningIdentity` parameter to your `gradle.properties`.

--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -40,6 +40,8 @@ or
 `cd samples/coroutines/kotlin`
 `./gradlew kotlin:build`  
 Coroutines are not supported on android for now.
+
+### iOS Signing
  
 Also on ios you should add you signing identity, as it is apple requirement, like:
 ```shell script

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -1,5 +1,6 @@
 val platform: String by project
 val armArch: String by project
+val iosSigningIdentity: String by project
 
 buildscript {
     repositories {
@@ -100,6 +101,29 @@ kotlin {
                 target.compilations.all {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library-extension:1.0.0")
+                    }
+                }
+                if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
+                    tasks.build {
+                        doLast {
+                            exec {
+                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosArm64/releaseShared/libkotlin.dylib")
+                            }
+                            exec {
+                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosArm64/releaseShared/libkotlin.dylib")
+                            }
+                        }
+                    }
+                } else if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosX64") {
+                    tasks.build {
+                        doLast {
+                            exec {
+                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosX64/releaseShared/libkotlin.dylib")
+                            }
+                            exec {
+                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosX64/releaseShared/libkotlin.dylib")
+                            }
+                        }
                     }
                 }
             } else {

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -73,20 +73,20 @@ kotlin {
             "macos" -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
             "ios" -> if (project.hasProperty("armArch")) {
                 when (armArch) {
-                    "arm64" -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-                    "X64" -> listOf(targetFromPreset(presets["iosX64"], "iosX64"))
-                    else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                    "arm64" -> listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
+                    "X64" -> listOf(targetFromPreset(presets["godotIosX64"], "iosX64"))
+                    else -> listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
                 }
-            } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-            else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
+            } else listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
+            else -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
         }
     } else {
         listOf(
                 targetFromPreset(presets["godotLinuxX64"], "linux"),
                 targetFromPreset(presets["godotMacosX64"], "macos"),
                 targetFromPreset(presets["godotMingwX64"], "windows"),
-                targetFromPreset(presets["iosArm64"], "iosArm64"),
-                targetFromPreset(presets["iosX64"], "iosX64")
+                targetFromPreset(presets["godotIosArm64"], "iosArm64"),
+                targetFromPreset(presets["godotIosX64"], "iosX64")
         )
     }
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -90,12 +90,12 @@ kotlin {
             } else listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
             "ios" -> if (project.hasProperty("armArch")) {
                 when (armArch) {
-                    "arm64" -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-                    "X64" -> listOf(targetFromPreset(presets["iosX64"], "iosX64"))
-                    else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                    "arm64" -> listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
+                    "X64" -> listOf(targetFromPreset(presets["godotIosX64"], "iosX64"))
+                    else -> listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
                 }
-            } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-            else -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
+            } else listOf(targetFromPreset(presets["godotIosArm64"], "iosArm64"))
+            else -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
         }
     } else {
         listOf(
@@ -104,8 +104,8 @@ kotlin {
                 targetFromPreset(presets["godotMingwX64"], "windows"),
                 targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"),
                 targetFromPreset(presets["godotAndroidNativeX64"], "androidX64"),
-                targetFromPreset(presets["iosArm64"], "iosArm64"),
-                targetFromPreset(presets["iosX64"], "iosX64")
+                targetFromPreset(presets["godotIosArm64"], "iosArm64"),
+                targetFromPreset(presets["godotIosX64"], "iosX64")
         )
     }
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,5 +1,6 @@
 val platform: String by project
 val armArch: String by project
+val iosSigningIdentity: String by project
 
 buildscript {
     repositories {
@@ -120,6 +121,29 @@ kotlin {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library:1.0.0")
                         implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                    }
+                }
+                if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
+                    tasks.build {
+                        doLast {
+                            exec {
+                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosArm64/debugShared/libkotlin.dylib")
+                            }
+                            exec {
+                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosArm64/debugShared/libkotlin.dylib")
+                            }
+                        }
+                    }
+                } else if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosX64") {
+                    tasks.build {
+                        doLast {
+                            exec {
+                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosX64/debugShared/libkotlin.dylib")
+                            }
+                            exec {
+                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosX64/debugShared/libkotlin.dylib")
+                            }
+                        }
                     }
                 }
             } else {

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 val platform: String by project
-val android_arch: String by project
+val armArch: String by project
 
 buildscript {
     repositories {
@@ -32,12 +32,16 @@ kotlin {
         sourceSets.create("windowsMain")
         sourceSets.create("androidArm64Main")
         sourceSets.create("androidX64Main")
+        sourceSets.create("iosArm64Main")
+        sourceSets.create("iosX64Main")
         configure(listOf(
                 sourceSets["macosMain"],
                 sourceSets["linuxMain"],
                 sourceSets["windowsMain"],
                 sourceSets["androidArm64Main"],
-                sourceSets["androidX64Main"]
+                sourceSets["androidX64Main"],
+                sourceSets["iosArm64Main"],
+                sourceSets["iosX64Main"]
         )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
@@ -75,13 +79,20 @@ kotlin {
             "windows" -> listOf(targetFromPreset(presets["godotMingwX64"], "windows"))
             "linux" -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
             "macos" -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
-            "android" -> if (project.hasProperty("android_arch")) {
-                when(android_arch) {
+            "android" -> if (project.hasProperty("armArch")) {
+                when(armArch) {
                     "X64" -> listOf(targetFromPreset(presets["godotAndroidNativeX64"], "androidX64"))
                     "arm64" -> listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
                     else -> listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
                 }
             } else listOf(targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"))
+            "ios" -> if (project.hasProperty("armArch")) {
+                when (armArch) {
+                    "arm64" -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                    "X64" -> listOf(targetFromPreset(presets["iosX64"], "iosX64"))
+                    else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                }
+            } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
             else -> listOf(targetFromPreset(presets["godotMacosX64"], "macos"))
         }
     } else {
@@ -90,7 +101,9 @@ kotlin {
                 targetFromPreset(presets["godotMacosX64"], "macos"),
                 targetFromPreset(presets["godotMingwX64"], "windows"),
                 targetFromPreset(presets["godotAndroidNativeArm64"], "androidArm64"),
-                targetFromPreset(presets["godotAndroidNativeX64"], "androidX64")
+                targetFromPreset(presets["godotAndroidNativeX64"], "androidX64"),
+                targetFromPreset(presets["iosArm64"], "iosArm64"),
+                targetFromPreset(presets["iosX64"], "iosX64")
         )
     }
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -53,7 +53,9 @@ kotlin {
                     sourceSets["linuxMain"],
                     sourceSets["windowsMain"],
                     sourceSets["androidArm64Main"],
-                    sourceSets["androidX64Main"]
+                    sourceSets["androidX64Main"],
+                    sourceSets["iosArm64Main"],
+                    sourceSets["iosX64Main"]
             )) {
                 sourceSet {
                     kotlin.srcDirs("src/main/kotlin")

--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -18,7 +18,7 @@ version = Dependencies.annotationsVersion
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
-val android_arch: String by project
+val armArch: String by project
 
 kotlin {
     if (project.hasProperty("platform")) {
@@ -26,13 +26,19 @@ kotlin {
             "windows" -> mingwX64("windows")
             "linux" -> linuxX64("linux")
             "macos" -> macosX64("macos")
-            "android" -> if (project.hasProperty("android_arch")) {
-                when(android_arch) {
+            "android" -> if (project.hasProperty("armArch")) {
+                when(armArch) {
                     "X64" -> androidNativeX64("androidX64")
                     "arm64" -> androidNativeArm64("androidArm64")
                     else -> androidNativeArm64("androidArm64")
                 }
             } else androidNativeArm64("androidArm64")
+            "ios" -> if (project.hasProperty("armArch")) {
+                when(armArch) {
+                    "arm64" -> iosArm64("iosArm64")
+                    "X64" -> iosX64("iosX64")
+                }
+            } else iosArm64("iosArm64")
             else -> linuxX64("linux")
         }
     } else {
@@ -41,6 +47,8 @@ kotlin {
         macosX64("macos")
         androidNativeX64("androidX64")
         androidNativeArm64("androidArm64")
+        iosArm64("iosArm64")
+        iosX64("iosX64")
     }
     jvm()
 

--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -80,7 +80,9 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey") && p
             userOrg = "utopia-rise"
             repo = "annotations"
 
-            name = "${project.name}-$platform"
+            val armString = if (project.hasProperty("armArch")) armArch else ""
+
+            name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"
             setLicenses("Apache-2.0")
             version(closureOf<com.jfrog.bintray.gradle.BintrayExtension.VersionConfig> {

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.*
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
+val armArch: String by project
 
 plugins {
     id("kotlin-multiplatform")
@@ -18,10 +19,14 @@ kotlin {
         sourceSets.create("macosMain")
         sourceSets.create("linuxMain")
         sourceSets.create("windowsMain")
+        sourceSets.create("iosArm64Main")
+        sourceSets.create("iosX64Main")
         configure(listOf(
                 sourceSets["macosMain"],
                 sourceSets["linuxMain"],
-                sourceSets["windowsMain"]
+                sourceSets["windowsMain"],
+                sourceSets["iosArm64Main"],
+                sourceSets["iosX64Main"]
         )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
@@ -33,13 +38,22 @@ kotlin {
                     "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
                     "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                     "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
+                    "ios" -> if (project.hasProperty("armArch")) {
+                        when (armArch) {
+                            "arm64" -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                            "X64" -> listOf(targetFromPreset(presets["iosX64"], "iosX64"))
+                            else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                        }
+                    } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {
                 listOf(
                         targetFromPreset(presets["linuxX64"], "linux"),
                         targetFromPreset(presets["macosX64"], "macos"),
-                        targetFromPreset(presets["mingwX64"], "windows")
+                        targetFromPreset(presets["mingwX64"], "windows"),
+                        targetFromPreset(presets["iosArm64"], "iosArm64"),
+                        targetFromPreset(presets["iosX64"], "iosX64")
                 )
             }
 

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 val bintrayUser: String by project
 val bintrayKey: String by project
 val platform: String by project
-val android_arch: String by project
+val armArch: String by project
 
 group = "org.godotengine.kotlin"
 version = Dependencies.godotLibraryVersion
@@ -21,12 +21,16 @@ kotlin {
         sourceSets.create("windowsMain")
         sourceSets.create("androidArm64Main")
         sourceSets.create("androidX64Main")
+        sourceSets.create("iosArm64Main")
+        sourceSets.create("iosX64Main")
         configure(listOf(
                 sourceSets["macosMain"],
                 sourceSets["linuxMain"],
                 sourceSets["windowsMain"],
                 sourceSets["androidArm64Main"],
-                sourceSets["androidX64Main"]
+                sourceSets["androidX64Main"],
+                sourceSets["iosArm64Main"],
+                sourceSets["iosX64Main"]
         )) {
             this.kotlin.srcDir("src/main/kotlin")
         }
@@ -38,13 +42,20 @@ kotlin {
                     "windows" -> listOf(targetFromPreset(presets["mingwX64"], "windows"))
                     "linux" -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                     "macos" -> listOf(targetFromPreset(presets["macosX64"], "macos"))
-                    "android" -> if (project.hasProperty("android_arch")) {
-                        when(android_arch) {
+                    "android" -> if (project.hasProperty("armArch")) {
+                        when(armArch) {
                             "X64" -> listOf(targetFromPreset(presets["androidNativeX64"], "androidX64"))
                             "arm64" -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                             else -> listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
                         }
                     } else listOf(targetFromPreset(presets["androidNativeArm64"], "androidArm64"))
+                    "ios" -> if (project.hasProperty("armArch")) {
+                        when (armArch) {
+                            "arm64" -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                            "X64" -> listOf(targetFromPreset(presets["iosX64"], "iosX64"))
+                            else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
+                        }
+                    } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
                     else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
                 }
             } else {
@@ -53,7 +64,9 @@ kotlin {
                         targetFromPreset(presets["macosX64"], "macos"),
                         targetFromPreset(presets["mingwX64"], "windows"),
                         targetFromPreset(presets["androidNativeArm64"], "androidArm64"),
-                        targetFromPreset(presets["androidNativeX64"], "androidX64")
+                        targetFromPreset(presets["androidNativeX64"], "androidX64"),
+                        targetFromPreset(presets["iosArm64"], "iosArm64"),
+                        targetFromPreset(presets["iosX64"], "iosX64")
                 )
             }
 
@@ -88,7 +101,9 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
             userOrg = "utopia-rise"
             repo = "kotlin-godot"
 
-            name = "${project.name}-$platform"
+            val armString = if (project.hasProperty("armArch")) armArch else ""
+
+            name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"
             setLicenses("Apache-2.0")
             version(closureOf<com.jfrog.bintray.gradle.BintrayExtension.VersionConfig> {


### PR DESCRIPTION
This adds support for ios platform and documentation on how to build for it.
Move `android_arch` parameters to `armArch`.
Add extra parameter to sample projects `iosSigningIdentity`, to sign produced shared library with apple developer account.
This has been tested on `iPod touch 6th generation (v12.4.5)`
This PR have to wait for #26 to be merged.
This resolves #4 