### PR TITLE
Added selectable build target using -PbuildTarget=release

### DIFF
--- a/COMPILING_FROM_SOURCE.md
+++ b/COMPILING_FROM_SOURCE.md
@@ -41,6 +41,8 @@ or
 `./gradlew kotlin:build`  
 Coroutines are not supported on android for now.
 
+To specify release or debug add: `-PbuildType=RELEASE` by default debug will be built if nothing is specified.
+
 ### iOS Signing
  
 Also on ios you should add you signing identity, as it is apple requirement, like:

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -49,6 +49,7 @@ Inside your `build.gradle.kts` file, you need to define the `godot-gradle-plugin
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
+val buildType: String? by project
 
 buildscript {
     repositories {
@@ -197,8 +198,16 @@ targets.forEach {
         if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
             println("Configuring target ${this.target.name}")
             this.target.binaries {
-                sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
-            }
+                    val libTarget = when(buildType?.toLowerCase()) {
+                        "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
+                        "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        else -> {
+                            logger.warn("Build target not specified, defaulting to DEBUG. To set release target, specify: -PbuildType=RELEASE")
+                            listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        }
+                    }
+                    sharedLib(libTarget)
+                }
             this.target.compilations.all {
                 dependencies {
                     implementation("org.godotengine.kotlin:godot-library:1.0.0")
@@ -242,6 +251,7 @@ If you followed along your `build.gradle.kts` file should look like this:
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
+val buildType: String? by project
 
 buildscript {
     repositories {

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -366,7 +366,15 @@ kotlin {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
                 println("Configuring target ${this.target.name}")
                 this.target.binaries {
-                    sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
+                    val libTarget = when(buildType?.toLowerCase()) {
+                        "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
+                        "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        else -> {
+                            logger.warn("Build target not specified, defaulting to DEBUG. To set release target, specify: -PbuildType=RELEASE")
+                            listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        }
+                    }
+                    sharedLib(libTarget)
                 }
                 this.target.compilations.all {
                     dependencies {

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
-val buildTarget: String? by project
+val buildType: String? by project
 
 buildscript {
     repositories {
@@ -97,11 +97,11 @@ kotlin {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
                 println("Configuring target ${this.target.name}")
                 this.target.binaries {
-                    val libTarget = when(buildTarget?.toLowerCase()) {
+                    val libTarget = when(buildType?.toLowerCase()) {
                         "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
                         "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
                         else -> {
-                            System.err.println("Build target not specified, defaulting to DEBUG. To set release target, specify: -Ptarget=RELEASE")
+                            logger.warn("Build target not specified, defaulting to DEBUG. To set release target, specify: -PbuildType=RELEASE")
                             listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
                         }
                     }

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
+val buildTarget: String? by project
 
 buildscript {
     repositories {
@@ -94,11 +95,19 @@ kotlin {
     targets.forEach { target ->
         target.compilations.getByName("main") {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
-                println("Configuring target ${target.name}")
+                println("Configuring target ${this.target.name}")
                 this.target.binaries {
-                    sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
+                    val libTarget = when(buildTarget?.toLowerCase()) {
+                        "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
+                        "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        else -> {
+                            System.err.println("Build target not specified, defaulting to DEBUG. To set release target, specify: -Ptarget=RELEASE")
+                            listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        }
+                    }
+                    sharedLib(libTarget)
                 }
-                target.compilations.all {
+                this.target.compilations.all {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library-extension:1.0.0")
                     }

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
+val buildTarget: String? by project
 
 buildscript {
     repositories {
@@ -115,7 +116,15 @@ kotlin {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
                 println("Configuring target ${this.target.name}")
                 this.target.binaries {
-                    sharedLib(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG))
+                    val libTarget = when(buildTarget?.toLowerCase()) {
+                        "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
+                        "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        else -> {
+                            System.err.println("Build target not specified, defaulting to DEBUG. To set release target, specify: -Ptarget=RELEASE")
+                            listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
+                        }
+                    }
+                    sharedLib(libTarget)
                 }
                 this.target.compilations.all {
                     dependencies {

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
-val buildTarget: String? by project
+val buildType: String? by project
 
 buildscript {
     repositories {
@@ -116,11 +116,11 @@ kotlin {
             if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
                 println("Configuring target ${this.target.name}")
                 this.target.binaries {
-                    val libTarget = when(buildTarget?.toLowerCase()) {
+                    val libTarget = when(buildType?.toLowerCase()) {
                         "release" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE)
                         "debug" -> listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
                         else -> {
-                            System.err.println("Build target not specified, defaulting to DEBUG. To set release target, specify: -Ptarget=RELEASE")
+                            logger.warn("Build target not specified, defaulting to DEBUG. To set release target, specify: -PbuildType=RELEASE")
                             listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
                         }
                     }


### PR DESCRIPTION
Implementation for #28
Just `target` was a loaded term within the build script, so I opted for `buildTarget` to differentiate it.

In my other PR #33 I establish a template for the kotlin side of projects `tools/kotlin_project_template`. Once we pull that in we can codify changes like this in the `build.gradle.kts` file in there and use that as the standard.