### PR TITLE
Hotfix/fix travis ci deploy

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -3,7 +3,7 @@ if [ $3 == "linux" ]; then
   ./gradlew :tools:entry-generator:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2
   ./gradlew :tools:api-classes-generator:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2
   ./gradlew :tools:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=kotlinMultiplatform
-  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=metadata
+  ./gradlew :tools:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=metadata
   ./gradlew :tools:godot-annotation-processor:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2
   ./gradlew :tools:kotlin-compiler-plugin:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2
   ./gradlew :tools:kotlin-compiler-native-plugin:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2
@@ -14,14 +14,14 @@ if [ $3 == "linux" ]; then
   ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=metadata
 fi
 
-if [ $3 == "android" || $3 == "ios" ]; then
-  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
+if [ $3 == "android" ] || [ $3 == "ios" ]; then
+  ./gradlew :tools:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
   ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
   if [ $3 == "ios" ]; then
       ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3 -ParmArch=$4
   fi
 else
-  ./gradlew :wrapper:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
+  ./gradlew :tools:annotations:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
   ./gradlew :wrapper:godot-library:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
   ./gradlew :wrapper:godot-library-extension:bintrayUpload -PbintrayUser=$1 -PbintrayKey=$2 -Pplatform=$3
 fi

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -202,7 +202,7 @@ targets.forEach {
             this.target.compilations.all {
                 dependencies {
                     implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                    implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                    implementation("org.godotengine.kotlin:annotations:0.0.1")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
@@ -361,7 +361,7 @@ kotlin {
                 this.target.compilations.all {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                        implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                        implementation("org.godotengine.kotlin:annotations:0.0.1")
                     }
                 }
                 if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,11 +9,11 @@ object Dependencies {
 
     const val godotLibraryVersion = "1.0.0"
     const val godotLibraryExtensionVersion = "1.0.0"
-    const val kotlinCompilerPluginVersion = "0.0.1-SNAPSHOT" //remember to bump the version in KotlinGodotSubplugin as well!
-    const val kotlinNativeCompilerPluginVersion = "0.0.1-SNAPSHOT" //remember to bump the version in KotlinGodotSubplugin as well!
+    const val kotlinCompilerPluginVersion = "0.0.1" //remember to bump the version in KotlinGodotSubplugin as well!
+    const val kotlinNativeCompilerPluginVersion = "0.0.1" //remember to bump the version in KotlinGodotSubplugin as well!
     const val godotGradlePluginVersion = "1.0.1"
-    const val godotAnnotationProcessorVersion = "0.0.1-SNAPSHOT"
+    const val godotAnnotationProcessorVersion = "0.0.1"
     const val entryGeneratorVersion = "1.0.0"
     const val apiClassesGeneratorVersion = "1.0.0"
-    const val annotationsVersion = "0.0.1-SNAPSHOT"
+    const val annotationsVersion = "0.0.1"
 }

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -120,7 +120,7 @@ kotlin {
                 this.target.compilations.all {
                     dependencies {
                         implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                        implementation("org.godotengine.kotlin:annotations:0.0.1-SNAPSHOT")
+                        implementation("org.godotengine.kotlin:annotations:0.0.1")
                     }
                 }
                 if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -101,12 +101,11 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey") && p
     bintray {
         user = bintrayUser
         key = bintrayKey
-        setPublications(platform)
+        val armString = if (project.hasProperty("armArch")) armArch else ""
+        setPublications(platform + armString.capitalize())
         pkg(delegateClosureOf<com.jfrog.bintray.gradle.BintrayExtension.PackageConfig> {
             userOrg = "utopia-rise"
             repo = "kotlin-godot"
-
-            val armString = if (project.hasProperty("armArch")) armArch else ""
 
             name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"

--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -39,7 +39,15 @@ kotlin {
                     "X64" -> iosX64("iosX64")
                 }
             } else iosArm64("iosArm64")
-            else -> linuxX64("linux")
+            else -> {
+                linuxX64("linux")
+                mingwX64("windows")
+                macosX64("macos")
+                androidNativeX64("androidX64")
+                androidNativeArm64("androidArm64")
+                iosArm64("iosArm64")
+                iosX64("iosX64")
+            }
         }
     } else {
         linuxX64("linux")
@@ -71,6 +79,24 @@ tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
 }
 
+tasks {
+    // workaround to upload gradle metadata file
+    // https://github.com/bintray/gradle-bintray-plugin/issues/229
+    withType<com.jfrog.bintray.gradle.tasks.BintrayUploadTask> {
+        doFirst {
+            publishing.publications.withType<MavenPublication> {
+                buildDir.resolve("publications/$name/module.json").also {
+                    if (it.exists()) {
+                        artifact(object: org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact(it) {
+                            override fun getDefaultExtension() = "module"
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
 if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey") && project.hasProperty("platform")) {
     bintray {
         user = bintrayUser
@@ -78,7 +104,7 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey") && p
         setPublications(platform)
         pkg(delegateClosureOf<com.jfrog.bintray.gradle.BintrayExtension.PackageConfig> {
             userOrg = "utopia-rise"
-            repo = "annotations"
+            repo = "kotlin-godot"
 
             val armString = if (project.hasProperty("armArch")) armArch else ""
 

--- a/tools/godot-annotation-processor/build.gradle.kts
+++ b/tools/godot-annotation-processor/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("maven")
     id("kotlin-kapt")
+    id("maven-publish")
     id("com.jfrog.bintray")
 }
 

--- a/tools/godot-annotation-processor/build.gradle.kts
+++ b/tools/godot-annotation-processor/build.gradle.kts
@@ -36,6 +36,14 @@ tasks.build {
     finalizedBy(tasks.install)
 }
 
+publishing {
+    publications {
+        register("godotAnnotationProcessor", MavenPublication::class.java) {
+            from(components["java"])
+        }
+    }
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/subplugin/KotlinGodotSubplugin.kt
+++ b/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/subplugin/KotlinGodotSubplugin.kt
@@ -24,12 +24,12 @@ class KotlinGodotSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
             groupId = "org.godotengine.kotlin",
             artifactId = "kotlin-compiler-plugin",
-            version = "0.0.1-SNAPSHOT" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
+            version = "0.0.1" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
     )
 
     override fun getNativeCompilerPluginArtifact() = SubpluginArtifact(
             groupId = "org.godotengine.kotlin",
             artifactId = "kotlin-compiler-native-plugin",
-            version = "0.0.1-SNAPSHOT" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
+            version = "0.0.1" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
     )
 }

--- a/tools/kotlin-compiler-native-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-native-plugin/build.gradle.kts
@@ -56,9 +56,9 @@ val shadowJar by tasks.getting(com.github.jengelman.gradle.plugins.shadow.tasks.
 
 publishing {
     publications {
-        create<MavenPublication>("shadow") {
+        register<MavenPublication>("godotCompilerNativePlugin") {
             configure<com.github.jengelman.gradle.plugins.shadow.ShadowExtension> {
-                component(this@create)
+                component(this@register)
             }
         }
     }

--- a/tools/kotlin-compiler-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-plugin/build.gradle.kts
@@ -29,6 +29,14 @@ kapt {
     includeCompileClasspath = true
 }
 
+publishing {
+    publications {
+        register("godotCompilerPlugin", MavenPublication::class.java) {
+            from(components["java"])
+        }
+    }
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/kotlin-compiler-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-plugin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("kotlin-kapt")
     id("maven")
+    id("maven-publish")
     id("com.jfrog.bintray")
 }
 

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -100,12 +100,11 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
     bintray {
         user = bintrayUser
         key = bintrayKey
-        setPublications(platform)
+        val armString = if (project.hasProperty("armArch")) armArch else ""
+        setPublications(platform + armString.capitalize())
         pkg(delegateClosureOf<com.jfrog.bintray.gradle.BintrayExtension.PackageConfig> {
             userOrg = "utopia-rise"
             repo = "kotlin-godot"
-
-            val armString = if (project.hasProperty("armArch")) armArch else ""
 
             name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -45,7 +45,13 @@ kotlin {
                             else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
                         }
                     } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-                    else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
+                    else -> listOf(
+                            targetFromPreset(presets["linuxX64"], "linux"),
+                            targetFromPreset(presets["macosX64"], "macos"),
+                            targetFromPreset(presets["mingwX64"], "windows"),
+                            targetFromPreset(presets["iosArm64"], "iosArm64"),
+                            targetFromPreset(presets["iosX64"], "iosX64")
+                    )
                 }
             } else {
                 listOf(
@@ -71,6 +77,24 @@ tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
 }
 
+tasks {
+    // workaround to upload gradle metadata file
+    // https://github.com/bintray/gradle-bintray-plugin/issues/229
+    withType<com.jfrog.bintray.gradle.tasks.BintrayUploadTask> {
+        doFirst {
+            publishing.publications.withType<MavenPublication> {
+                buildDir.resolve("publications/$name/module.json").also {
+                    if (it.exists()) {
+                        artifact(object: org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact(it) {
+                            override fun getDefaultExtension() = "module"
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
 if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
         && project.hasProperty("platform")) {
     bintray {
@@ -81,7 +105,9 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
             userOrg = "utopia-rise"
             repo = "kotlin-godot"
 
-            name = "${project.name}-$platform"
+            val armString = if (project.hasProperty("armArch")) armArch else ""
+
+            name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"
             setLicenses("Apache-2.0")
             version(closureOf<com.jfrog.bintray.gradle.BintrayExtension.VersionConfig> {

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -122,12 +122,11 @@ if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")
     bintray {
         user = bintrayUser
         key = bintrayKey
-        setPublications(platform)
+        val armString = if (project.hasProperty("armArch")) armArch else ""
+        setPublications(platform + armString.capitalize())
         pkg(delegateClosureOf<com.jfrog.bintray.gradle.BintrayExtension.PackageConfig> {
             userOrg = "utopia-rise"
             repo = "kotlin-godot"
-
-            val armString = if (project.hasProperty("armArch")) armArch else ""
 
             name = "${project.name}-$platform$armString"
             vcsUrl = "https://github.com/utopia-rise/kotlin-godot-wrapper"

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -56,7 +56,15 @@ kotlin {
                             else -> listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
                         }
                     } else listOf(targetFromPreset(presets["iosArm64"], "iosArm64"))
-                    else -> listOf(targetFromPreset(presets["linuxX64"], "linux"))
+                    else -> listOf(
+                            targetFromPreset(presets["linuxX64"], "linux"),
+                            targetFromPreset(presets["macosX64"], "macos"),
+                            targetFromPreset(presets["mingwX64"], "windows"),
+                            targetFromPreset(presets["androidNativeArm64"], "androidArm64"),
+                            targetFromPreset(presets["androidNativeX64"], "androidX64"),
+                            targetFromPreset(presets["iosArm64"], "iosArm64"),
+                            targetFromPreset(presets["iosX64"], "iosX64")
+                    )
                 }
             } else {
                 listOf(
@@ -89,6 +97,24 @@ kotlin {
 
 tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
+}
+
+tasks {
+    // workaround to upload gradle metadata file
+    // https://github.com/bintray/gradle-bintray-plugin/issues/229
+    withType<com.jfrog.bintray.gradle.tasks.BintrayUploadTask> {
+        doFirst {
+            publishing.publications.withType<MavenPublication> {
+                buildDir.resolve("publications/$name/module.json").also {
+                    if (it.exists()) {
+                        artifact(object: org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact(it) {
+                            override fun getDefaultExtension() = "module"
+                        })
+                    }
+                }
+            }
+        }
+    }
 }
 
 if (project.hasProperty("bintrayUser") && project.hasProperty("bintrayKey")


### PR DESCRIPTION
This fixes artifacts deployment and resolution on bintray. It enables user to use our bintray to get artifacts, as FakeRelease proves it.
Here is bintray with publish test: https://bintray.com/beta/#/utopia-rise/kotlin-godot
Also I will delete FakeRelease and artifacts on bintray when merged.