### PR TITLE
Set source target compatibility to java 8

### DIFF
--- a/tools/annotations/build.gradle.kts
+++ b/tools/annotations/build.gradle.kts
@@ -20,6 +20,11 @@ val bintrayKey: String by project
 val platform: String by project
 val armArch: String by project
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 kotlin {
     if (project.hasProperty("platform")) {
         when (platform) {

--- a/tools/api-classes-generator/build.gradle.kts
+++ b/tools/api-classes-generator/build.gradle.kts
@@ -44,6 +44,11 @@ tasks.clean {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/entry-generator/build.gradle.kts
+++ b/tools/entry-generator/build.gradle.kts
@@ -40,6 +40,11 @@ tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/godot-annotation-processor/build.gradle.kts
+++ b/tools/godot-annotation-processor/build.gradle.kts
@@ -36,6 +36,11 @@ tasks.build {
     finalizedBy(tasks.install)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 publishing {
     publications {
         register("godotAnnotationProcessor", MavenPublication::class.java) {

--- a/tools/godot-gradle-plugin/build.gradle.kts
+++ b/tools/godot-gradle-plugin/build.gradle.kts
@@ -51,6 +51,11 @@ tasks.build {
     finalizedBy(tasks.publishToMavenLocal)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/kotlin-compiler-native-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-native-plugin/build.gradle.kts
@@ -77,6 +77,11 @@ kapt {
     includeCompileClasspath = true
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 val bintrayUser: String by project
 val bintrayKey: String by project
 

--- a/tools/kotlin-compiler-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-plugin/build.gradle.kts
@@ -25,6 +25,11 @@ tasks.build {
     finalizedBy(tasks.install)
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 kapt {
     includeCompileClasspath = true
 }

--- a/wrapper/godot-library-extension/build.gradle.kts
+++ b/wrapper/godot-library-extension/build.gradle.kts
@@ -14,6 +14,11 @@ plugins {
 group = "org.godotengine.kotlin"
 version = Dependencies.godotLibraryExtensionVersion
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 kotlin {
     sourceSets {
         sourceSets.create("macosMain")

--- a/wrapper/godot-library/build.gradle.kts
+++ b/wrapper/godot-library/build.gradle.kts
@@ -14,6 +14,11 @@ val armArch: String by project
 group = "org.godotengine.kotlin"
 version = Dependencies.godotLibraryVersion
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 kotlin {
     sourceSets {
         sourceSets.create("macosMain")


### PR DESCRIPTION
This should prevent the source code to be build for higher java versions when built locally, so it stays compatible with whatever java version the user is using to build he's games.