### PR TITLE
Fix dependency resolution

### DIFF
--- a/tools/entry-generator/build.gradle.kts
+++ b/tools/entry-generator/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     compileOnly(project(":tools:annotations"))
-    implementation(project(":tools:annotations-internal"))
+    compileOnly(project(":tools:annotations-internal"))
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable") //used for class analisation without reflection
     implementation("de.jensklingenberg:mpapt-runtime:${Dependencies.mpaptVersion}")
     implementation("com.squareup:kotlinpoet:${Dependencies.kotlinPoetVersion}")

--- a/tools/godot-annotation-processor/build.gradle.kts
+++ b/tools/godot-annotation-processor/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(project(":tools:annotations"))
+    implementation(project(":tools:annotations-internal"))
     implementation(project(":tools:entry-generator"))
     implementation("de.jensklingenberg:mpapt-runtime:${Dependencies.mpaptVersion}")
     implementation("com.squareup:kotlinpoet:${Dependencies.kotlinPoetVersion}")


### PR DESCRIPTION
Game project could not resolve the dependencies for the internal annotations because they didn't knew which dependency was needed (native and which target, jvm)