### PR TITLE
Implement usage of newer gdnative apis

### DIFF
--- a/wrapper/godot-library/src/main/c_interop/godot.def
+++ b/wrapper/godot-library/src/main/c_interop/godot.def
@@ -1471,6 +1471,10 @@ godot_bool godot_dictionary_empty(const godot_dictionary * p_self) {
        return api->godot_dictionary_empty(p_self);
 }
 
+godot_dictionary godot_dictionary_duplicate(const godot_dictionary * p_self, const godot_bool deep) {
+       return api12->godot_dictionary_duplicate(p_self, deep);
+}
+
 void godot_dictionary_clear(godot_dictionary * p_self) {
        return api->godot_dictionary_clear(p_self);
 }

--- a/wrapper/godot-library/src/main/c_interop/registrations.h
+++ b/wrapper/godot-library/src/main/c_interop/registrations.h
@@ -7,6 +7,9 @@
 
 
 const godot_gdnative_core_api_struct *api = NULL;
+const godot_gdnative_core_1_1_api_struct *api11 = NULL;
+const godot_gdnative_core_1_2_api_struct *api12 = NULL;
+
 const godot_gdnative_ext_nativescript_api_struct *nativescript_api = NULL;
 void *nativescript_handle = NULL;
 
@@ -14,6 +17,8 @@ void *nativescript_handle = NULL;
 
 static void godot_wrapper_gdnative_init(godot_gdnative_init_options *p_options) {
     api = p_options->api_struct;
+    api11 = (godot_gdnative_core_1_1_api_struct *) (api->next);
+    api12 = (godot_gdnative_core_1_2_api_struct *) (api11->next);
 
     for (int i = 0; i < api-> num_extensions; i++) {
         switch (api->extensions[i]->type) {

--- a/wrapper/godot-library/src/main/kotlin/godot/core/Dictionary.kt
+++ b/wrapper/godot-library/src/main/kotlin/godot/core/Dictionary.kt
@@ -45,6 +45,8 @@ class Dictionary: CoreType {
 
     fun isEmpty(): Boolean = godot_dictionary_empty(nativeValue)
 
+    fun duplicate(deep: Boolean = false): Dictionary = Dictionary(godot_dictionary_duplicate(nativeValue, deep))
+
     override fun hashCode(): Int = godot_dictionary_hash(nativeValue)
 
     fun size(): Int = godot_dictionary_size(nativeValue)


### PR DESCRIPTION
This PR adds the newer gdnative api's so we are now able to use them as well.
The Dictionary duplicate function was added as an example of such a function.