### PR TITLE
Fix entry generation tasks for projects with additional configurations

### DIFF
--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
 val platform: String by project
 val armArch: String by project
@@ -96,7 +95,7 @@ kotlin {
     }
 }
 
-fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") KotlinTarget) {
+fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetbrains.kotlin.gradle.plugin.KotlinTarget) {
     kotlinTarget.compilations.getByName("main") {
         if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
             println("Configuring target ${target.name}")

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+
 val platform: String by project
 val armArch: String by project
 val iosSigningIdentity: String by project
@@ -35,6 +37,7 @@ configure<org.godotengine.kotlin.gradleplugin.KotlinGodotPluginExtension> {
     }
     this.godotProjectPath = "${project.rootDir.absolutePath}/.."
     this.libraryPath = "samples.gdnlib"
+    this.configureTargetAction = ::configureTargetAction
 }
 
 kotlin {
@@ -59,7 +62,7 @@ kotlin {
         }
     }
 
-    val targets = if (project.hasProperty("platform")) {
+    if (project.hasProperty("platform")) {
         when (platform) {
             "windows" -> listOf(targetFromPreset(presets["godotMingwX64"], "windows"))
             "linux" -> listOf(targetFromPreset(presets["godotLinuxX64"], "linux"))
@@ -91,43 +94,43 @@ kotlin {
                 targetFromPreset(presets["godotIosX64"], "iosX64")
         )
     }
+}
 
-    targets.forEach { target ->
-        target.compilations.getByName("main") {
-            if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
-                println("Configuring target ${target.name}")
-                target.compilations.all {
-                    dependencies {
-                        implementation("org.godotengine.kotlin:godot-library:1.0.0")
-                        implementation("org.godotengine.kotlin:annotations:0.0.2")
-                    }
+fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") KotlinTarget) {
+    kotlinTarget.compilations.getByName("main") {
+        if (this is org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation) {
+            println("Configuring target ${target.name}")
+            target.compilations.all {
+                dependencies {
+                    implementation("org.godotengine.kotlin:godot-library:1.0.0")
+                    implementation("org.godotengine.kotlin:annotations:0.0.2")
                 }
-                if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
-                    tasks.build {
-                        doLast {
-                            exec {
-                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosArm64/debugShared/libkotlin.dylib")
-                            }
-                            exec {
-                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosArm64/debugShared/libkotlin.dylib")
-                            }
-                        }
-                    }
-                } else if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosX64") {
-                    tasks.build {
-                        doLast {
-                            exec {
-                                commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosX64/debugShared/libkotlin.dylib")
-                            }
-                            exec {
-                                commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosX64/debugShared/libkotlin.dylib")
-                            }
-                        }
-                    }
-                }
-            } else {
-                System.err.println("Not a native target! TargetName: ${target.name}")
             }
+            if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
+                tasks.build {
+                    doLast {
+                        exec {
+                            commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosArm64/debugShared/libkotlin.dylib")
+                        }
+                        exec {
+                            commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosArm64/debugShared/libkotlin.dylib")
+                        }
+                    }
+                }
+            } else if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosX64") {
+                tasks.build {
+                    doLast {
+                        exec {
+                            commandLine = listOf("codesign", "-f", "-s", iosSigningIdentity, "build/bin/iosX64/debugShared/libkotlin.dylib")
+                        }
+                        exec {
+                            commandLine = listOf("install_name_tool", "-id", "@executable_path/dylibs/ios/libkotlin.dylib", "build/bin/iosX64/debugShared/libkotlin.dylib")
+                        }
+                    }
+                }
+            }
+        } else {
+            System.err.println("Not a native target! TargetName: ${target.name}")
         }
     }
 }

--- a/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/KotlinGodotPlugin.kt
+++ b/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/KotlinGodotPlugin.kt
@@ -12,9 +12,11 @@ open class KotlinGodotPluginExtension {
     var libraryPath = ""
     var godotProjectPath = ""
     var releaseType = org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG
+    var configureTargetAction: (target: org.jetbrains.kotlin.gradle.plugin.KotlinTarget) -> Unit = {}
+
 
     override fun toString(): String {
-        return "KotlinGodotPluginExtension(kotlinVersion='$kotlinVersion', libraryPath='$libraryPath', godotProjectPath='$godotProjectPath', releaseType=$releaseType)"
+        return "KotlinGodotPluginExtension(kotlinVersion='$kotlinVersion', libraryPath='$libraryPath', godotProjectPath='$godotProjectPath', releaseType=$releaseType, configureTargetAction=$configureTargetAction)"
     }
 }
 


### PR DESCRIPTION
For the entry generation we add an additional compilation step to generate the entry files (a dummyTarget).
With the previous approach it worked as long as the user had no other configurations on his targets than normal dependencies.
But if the user defines other configurations like cinterops for his game (like @2shady4u does in his sqlite-wrapper) the entry generation compilation task failed as no cinterop was done for it as it was not configured for it.

This PR let's the user configure his targets in a separate function that is passed to our plugin and is added to each target the user configures including our dummyTarget.
Like this all configurations the user applies to his targets, are also applied for the dummy target.