### PR TITLE
Fix bug in entry generation where signal parameter strings where not escaped

### DIFF
--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/GDNativeFunctionBindingGenerator.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/GDNativeFunctionBindingGenerator.kt
@@ -160,7 +160,7 @@ class GDNativeFunctionBindingGenerator {
         val signalArgumentsArrayString = buildString {
             append(",·arrayOf(")
             arguments.forEachIndexed { index, pair ->
-                append("${pair.first}·to·${pair.second}")
+                append("\"${pair.first}\"·to·${pair.second}")
                 if (index != arguments.size - 1) {
                     append(",·")
                 }


### PR DESCRIPTION
This fixes a bug where signal parameter name strings were not escaped.
ex: `registerSignal("godot.samples.coroutines.Ball", "move", arrayOf(step to Variant.Type.VECTOR2), arrayOf(Variant(godot.core.Vector2())))`
`step` was missing the `"`.
Now it's correctly escaped and becomes `registerSignal("godot.samples.coroutines.Ball", "move", arrayOf("step" to Variant.Type.VECTOR2), arrayOf(Variant(godot.core.Vector2())))`