### PR TITLE
Feature/registration default value improvement

### DIFF
--- a/API_DIFFERENCES.md
+++ b/API_DIFFERENCES.md
@@ -54,7 +54,7 @@ To use `yield` keyword in your program **library extension** is needed.
                 }
                 target.compilations.all {
                     dependencies {
-                        implementation("org.godotengine.kotlin:godot-library-extension:0.1.0-3.2") // <-- This one here
+                        implementation("org.godotengine.kotlin:godot-library-extension:0.1.1-3.2") // <-- This one here
                     }
                 }
             } else {

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -59,7 +59,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -198,8 +198,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") KotlinTa
             println("Configuring target ${target.name}")
             target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library:0.1.0-3.2")  // or implementation("org.godotengine.kotlin:godot-library-extension:0.1.0-3.2") if you want coroutines like yield
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library:0.1.1-3.2")  // or implementation("org.godotengine.kotlin:godot-library-extension:0.1.1-3.2") if you want coroutines like yield
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {
@@ -249,7 +249,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -353,8 +353,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetb
             println("Configuring target ${target.name}")
             target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library:0.1.0-3.2") // or implementation("org.godotengine.kotlin:godot-library-extension:1.0.0") if you want coroutines like yield
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library:0.1.1-3.2") // or implementation("org.godotengine.kotlin:godot-library-extension:1.0.0") if you want coroutines like yield
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/REGISTRATION.md
+++ b/REGISTRATION.md
@@ -108,7 +108,7 @@ val nodePathAsString = "Some/Path/To/A/Node"
 @RegisterProperty(true)
 var aProperty: Boolean = NodePath(nodePathAsString)
 ```
-If you try to do that, you will get a unknown reference exception!
+If you try to do that, you will get a exception during compilation!
 
 ## Examples:  
 **Property exported, visible in the editor, with default value 300:**

--- a/REGISTRATION.md
+++ b/REGISTRATION.md
@@ -75,7 +75,6 @@ The annotation takes the following arguments:
 | argument name   | type         | required | description |
 | --------------- | ------------ | -------- | ----------- |
 | visibleInEditor | Boolean      | yes      | defines whether the property is visible in the editor or not
-| defaultValue    | String       | yes      | defines the default value of the property. Note: A string has to be defined with escaped `"`. See the examples. Note: the default value has a higher priority than the one defined in the script! Godot will override the value defined in script with the value defined in the annotation on initialization! 
 | rpcMode         | RPCMode      | no       | defines how/and if this property can be set over the network. The same functionality can be achieved with the corresponding RpcMode annotations (read below)
 | propertyHint    | PropertyHint | no       | you can provide a property hint for the editor (so you have a texture picker for example)
 | hintString      | String       | no       | you can provide a hint string in addition to the propertyHint. See the [Godot documentation](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_exports.html) on how they should be formatted.
@@ -83,31 +82,31 @@ The annotation takes the following arguments:
 Examples:  
 **Property exported, visible in the editor, with default value 300:**
 ```kotlin
-@RegisterProperty(true, "300")
+@RegisterProperty(true)
 var xVel = 300
 ```
 
-**Property exported, visible in the editor, with default string value "aStringValue":**
+**Property exported, visible in the editor, with default string value "someString":**
 ```kotlin
-@RegisterProperty(true, "\"aStringValue\"")
+@RegisterProperty(true)
 var xVel = "someString"
 ```
 
 **Property exported, not visible in the editor, with default instance of class:**
 ```kotlin
-@RegisterProperty(false, "fully.qualified.AClassWithDefaultConstructor()")
-lateinit var aClassInstance: AClassWithDefaultConstructor
+@RegisterProperty(false)
+var aClassInstance: AClassWithDefaultConstructor = AClassWithDefaultConstructor()
 ```
 
 **Property exported, not visible in the editor, with default value 300, rpcMode RemoteSync:**
 ```kotlin
-@RegisterProperty(false, "300", RPCMode.RemoteSync)
+@RegisterProperty(false, RPCMode.RemoteSync)
 var xVel = 300
 ```
 
 **Property exported, visible in the editor, with default value 300, rpcMode Disabled, typeHint Range, with hintString:**
 ```kotlin
-@RegisterProperty(false, "300", propertyHint = PropertyHint.Range, hintString = "0,100000,1000,or_greater")
+@RegisterProperty(false, propertyHint = PropertyHint.Range, hintString = "0,100000,1000,or_greater")
 var xVel = 300
 ```
 
@@ -127,7 +126,7 @@ Example:
 **Property exported, not visible in the editor, with default value 300, rpcMode RemoteSync:**
 ```kotlin
 @RemoteSync
-@RegisterProperty(false, "300")
+@RegisterProperty(false)
 var xVel = 300
 ```
 
@@ -162,13 +161,6 @@ Also like in GDScript you can connect signals by method name as string:
 instanceOfClass.connect("startGame", this, "gameStarted")
 ```
 
-### Default arguments:
-You can also provide default arguments for signals in the annotation. But note: the number of default arguments must match the number of arguments the signals function has:
-```kotlin
-@RegisterSignal("\"asStringArgument\"", "1", "fully.qualified.InstanceOfClass()")
-fun startGame(aStringArgument: String, anIntegerArgument: Int, aClassInstance: InstanceOfClass) {}
-```
-
 ## The more typesafe way:
 We strongly recommend using signals this way, as it provides more safety against typo's, more typesafety and better refactoring support.
 
@@ -193,18 +185,7 @@ Safe:
 instanceOfClass.connect(ClassName.Signal::startGame.name, this, this::gameStarted.name)
 ```
 
-### Default arguments
-You can also provide default arguments for signals in the annotation. But note: the number of default arguments must match the number of arguments the signals function has:
-```kotlin
-@RegisterClass
-class EmitingClass {
-    interface Signal {
-        @RegisterSignal("\"asStringArgument\"", "1", "fully.qualified.InstanceOfClass()")
-        fun startGame(aStringArgument: String, anIntegerArgument: Int, aClassInstance: InstanceOfClass) {}
-    }
-}
-```
-If you implement above example you might see why we recommend this way of using signals:
+If you implement a signal you might see why we recommend this way of using signals:
 ```kotlin
 @RegisterClass
 class ListeningClass: EmitingClass.Signal { // <- Note the interface implementation
@@ -241,17 +222,12 @@ class ListeningClass: EmitingClass.Signal { // <- Note the interface implementat
 | argument name   | type         | required | description |
 | --------------- | ------------ | -------- | ----------- |
 | visibleInEditor | Boolean      | yes      | defines whether the property is visible in the editor or not
-| defaultValue    | String       | yes      | defines the default value of the property. Note: A string has to be defined with escaped `"`. See the examples. Note: the default value has a higher priority than the one defined in the script! Godot will override the value defined in script with the value defined in the annotation on initialization! 
 | rpcMode         | RPCMode      | no       | defines how/and if this property can be set over the network. The same functionality can be achieved with the corresponding RpcMode annotations (read below)
 | propertyHint    | PropertyHint | no       | you can provide a property hint for the editor (so you have a texture picker for example)
 | hintString      | String       | no       | you can provide a hint string in addition to the propertyHint. See the [Godot documentation](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_exports.html) on how they should be formatted.
 <br>
 
 **@RegisterSignal**
-
-| argument name   | type         | required | description |
-| --------------- | ------------ | -------- | ----------- |
-| defaultValues   | vararg String| no       | default arguments which godot provides when the signal is emited with less arguments. Number of default arguments has to match arguments of signal function!
 <br>
 
 **RPC Annotations:**  

--- a/REGISTRATION.md
+++ b/REGISTRATION.md
@@ -4,6 +4,8 @@ To have access to Kotlin classes from Godot you have to register them. In order 
 * [Classes](#classes)
 * [Functions](#functions)
 * [Properties](#properties)
+    * [Default Value](#default-value)
+    * [Examples](#examples)
 * [RPC Annotations](#rpc-annotations)
 * [Signals](#signals)
     * [The Godot way](#the-godot-way)
@@ -79,7 +81,36 @@ The annotation takes the following arguments:
 | propertyHint    | PropertyHint | no       | you can provide a property hint for the editor (so you have a texture picker for example)
 | hintString      | String       | no       | you can provide a hint string in addition to the propertyHint. See the [Godot documentation](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_exports.html) on how they should be formatted.
 
-Examples:  
+## Default Value
+The default value Godot needs to properly handle your property is taken from the value you assigned the property with.  
+You cannot register a `lateinit` Property and the property value declaration cannot be a function call or another property!  
+**Valid:**
+```kotlin
+@RegisterProperty(true)
+var aProperty: Boolean = true
+```
+**Invalid:**
+```kotlin
+fun foo() = false
+
+@RegisterProperty(true)
+var aProperty: Boolean = foo()
+```
+**Valid:**
+```kotlin
+@RegisterProperty(true)
+var aProperty: Boolean = NodePath("Some/Path/To/A/Node")
+```
+**Invalid:**
+```kotlin
+val nodePathAsString = "Some/Path/To/A/Node"
+
+@RegisterProperty(true)
+var aProperty: Boolean = NodePath(nodePathAsString)
+```
+If you try to do that, you will get a unknown reference exception!
+
+## Examples:  
 **Property exported, visible in the editor, with default value 300:**
 ```kotlin
 @RegisterProperty(true)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,14 +7,14 @@ object Dependencies {
     const val shadowJarPluginVersion = "5.0.0"
     const val kotlinPoetVersion = "1.5.0"
 
-    const val godotLibraryVersion = "0.1.0-3.2"
-    const val godotLibraryExtensionVersion = "0.1.0-3.2"
-    const val kotlinCompilerPluginVersion = "0.1.0-3.2" //remember to bump the version in KotlinGodotSubplugin as well!
-    const val kotlinNativeCompilerPluginVersion = "0.1.0-3.2" //remember to bump the version in KotlinGodotSubplugin as well!
-    const val godotGradlePluginVersion = "0.1.0-3.2"
-    const val godotAnnotationProcessorVersion = "0.1.0-3.2"
-    const val entryGeneratorVersion = "0.1.0-3.2"
-    const val apiClassesGeneratorVersion = "0.1.0-3.2"
-    const val annotationsVersion = "0.1.0-3.2"
-    const val internalAnnotationsVersion = "0.1.0-3.2"
+    const val godotLibraryVersion = "0.1.1-3.2"
+    const val godotLibraryExtensionVersion = "0.1.1-3.2"
+    const val kotlinCompilerPluginVersion = "0.1.1-3.2" //remember to bump the version in KotlinGodotSubplugin as well!
+    const val kotlinNativeCompilerPluginVersion = "0.1.1-3.2" //remember to bump the version in KotlinGodotSubplugin as well!
+    const val godotGradlePluginVersion = "0.1.1-3.2"
+    const val godotAnnotationProcessorVersion = "0.1.1-3.2"
+    const val entryGeneratorVersion = "0.1.1-3.2"
+    const val apiClassesGeneratorVersion = "0.1.1-3.2"
+    const val annotationsVersion = "0.1.1-3.2"
+    const val internalAnnotationsVersion = "0.1.1-3.2"
 }

--- a/samples/benchmark/bunnymark/kotlin/build.gradle.kts
+++ b/samples/benchmark/bunnymark/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -116,8 +116,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetb
             println("Configuring target ${this.target.name}")
             this.target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.0-3.2")
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.1-3.2")
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/samples/benchmark/gamelife/kotlin/build.gradle.kts
+++ b/samples/benchmark/gamelife/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -116,8 +116,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetb
             println("Configuring target ${this.target.name}")
             this.target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.0-3.2")
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.1-3.2")
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -116,8 +116,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetb
             println("Configuring target ${this.target.name}")
             this.target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.0-3.2")
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library-extension:0.1.1-3.2")
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/samples/coroutines/kotlin/src/main/kotlin/godot/samples/coroutines/Ball.kt
+++ b/samples/coroutines/kotlin/src/main/kotlin/godot/samples/coroutines/Ball.kt
@@ -15,7 +15,7 @@ class Ball : Node2D() {
     var moveSpeed = 2.0
 
     interface Signal {
-        @RegisterSignal("godot.core.Vector2()")
+        @RegisterSignal
         fun move(step: Vector2) {}
     }
 

--- a/samples/coroutines/kotlin/src/main/kotlin/godot/samples/coroutines/MirrorBall.kt
+++ b/samples/coroutines/kotlin/src/main/kotlin/godot/samples/coroutines/MirrorBall.kt
@@ -10,7 +10,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 @RegisterClass("Scripts/")
 class MirrorBall : Node2D() {
 
-    @RegisterProperty(true, "godot.core.NodePath(\"../Ball\")")
+    @RegisterProperty(true)
     var ballPath: NodePath = NodePath("../Ball")
     var center = Vector2()
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.0-3.2")
+        classpath("org.godotengine.kotlin:godot-gradle-plugin:0.1.1-3.2")
     }
 }
 
@@ -101,8 +101,8 @@ fun configureTargetAction(kotlinTarget: @ParameterName(name = "target") org.jetb
             println("Configuring target ${target.name}")
             target.compilations.all {
                 dependencies {
-                    implementation("org.godotengine.kotlin:godot-library:0.1.0-3.2")
-                    implementation("org.godotengine.kotlin:annotations:0.1.0-3.2")
+                    implementation("org.godotengine.kotlin:godot-library:0.1.1-3.2")
+                    implementation("org.godotengine.kotlin:annotations:0.1.1-3.2")
                 }
             }
             if (project.hasProperty("iosSigningIdentity") && this.target.name == "iosArm64") {

--- a/samples/games/kotlin/gradle.properties
+++ b/samples/games/kotlin/gradle.properties
@@ -1,1 +1,2 @@
 #kotlin.native.jvmArgs=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006
+platform=linux

--- a/samples/games/kotlin/gradle.properties
+++ b/samples/games/kotlin/gradle.properties
@@ -1,2 +1,1 @@
 #kotlin.native.jvmArgs=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006
-platform=linux

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
@@ -9,7 +9,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 @RegisterClass("Games/CatchBall/Scripts")
 class Player: KinematicBody() {
 
-    @RegisterProperty(true, "6")
+    @RegisterProperty(true)
     var speed = 6.0
 
     @RegisterFunction

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Mob.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Mob.kt
@@ -10,9 +10,9 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 
 @RegisterClass("Games/Dodge/Scripts")
 class Mob: RigidBody2D() {
-    @RegisterProperty(true, "150")
+    @RegisterProperty(true)
     var minSpeed = 150
-    @RegisterProperty(true, "250")
+    @RegisterProperty(true)
     var maxSpeed = 250
     val animationList = arrayOf("fly", "walk", "swim")
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
@@ -12,7 +12,7 @@ import org.godotengine.kotlin.annotation.RegisterSignal
 @RegisterClass("Games/Dodge/Scripts")
 class Player : Area2D() {
 
-    @RegisterProperty(true, "400")
+    @RegisterProperty(true)
     var speed: Int = 400
     lateinit var screensize: Vector2
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
@@ -14,9 +14,6 @@ class Ball: KinematicBody2D() {
     @RegisterProperty(true)
     var yVel = 300
 
-    @RegisterProperty(true) //TODO: cedric -> remove!!!
-    var testProperty = NodePath("some/node/path")
-
     lateinit var velocity: Vector2
     lateinit var visibilityNotifier2D: VisibilityNotifier2D
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
@@ -9,9 +9,9 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 @RegisterClass("Games/Pong/Scripts")
 class Ball: KinematicBody2D() {
 
-    @RegisterProperty(true, "300")
+    @RegisterProperty(true)
     var xVel = 300
-    @RegisterProperty(true, "300")
+    @RegisterProperty(true)
     var yVel = 300
     lateinit var velocity: Vector2
     lateinit var visibilityNotifier2D: VisibilityNotifier2D

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Ball.kt
@@ -13,6 +13,10 @@ class Ball: KinematicBody2D() {
     var xVel = 300
     @RegisterProperty(true)
     var yVel = 300
+
+    @RegisterProperty(true) //TODO: cedric -> remove!!!
+    var testProperty = NodePath("some/node/path")
+
     lateinit var velocity: Vector2
     lateinit var visibilityNotifier2D: VisibilityNotifier2D
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Enemy.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Enemy.kt
@@ -9,7 +9,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 @RegisterClass("Games/Pong/Scripts")
 class Enemy: KinematicBody2D() {
 
-    @RegisterProperty(true, "400")
+    @RegisterProperty(true)
     var speed = 400
 
     @RegisterFunction

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/pong/Player.kt
@@ -9,7 +9,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 @RegisterClass("Games/Pong/Scripts")
 class Player: KinematicBody2D() {
 
-    @RegisterProperty(true, "400")
+    @RegisterProperty(true)
     var speed = 400
 
     @RegisterFunction

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/Enemy.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/Enemy.kt
@@ -8,7 +8,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 
 @RegisterClass("Games/Shmup/Scripts")
 class Enemy: Area2D() {
-    @RegisterProperty(true, "2")
+    @RegisterProperty(true)
     var health = 2
     lateinit var bullet: NativeScript
     lateinit var camera: Node

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/shmup/Player.kt
@@ -12,7 +12,7 @@ import org.godotengine.kotlin.annotation.RegisterProperty
 class Player: KinematicBody2D() {
     var shootTime = 0
     var shooting = false
-    @RegisterProperty(true, "10")
+    @RegisterProperty(true)
     var speed = 600.0
     lateinit var Bullet: PackedScene
 

--- a/tools/annotations/src/androidArm64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/androidArm64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -7,7 +7,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/androidX64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/androidX64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -7,7 +7,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/commonMain/kotlin/org/godotengine/kotlin/annotation/Signal.kt
+++ b/tools/annotations/src/commonMain/kotlin/org/godotengine/kotlin/annotation/Signal.kt
@@ -2,4 +2,4 @@ package org.godotengine.kotlin.annotation
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class RegisterSignal(vararg val defaultValues: String)
+annotation class RegisterSignal

--- a/tools/annotations/src/iosArm64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/iosArm64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -9,7 +9,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/iosX64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/iosX64Main/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -9,7 +9,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/linuxMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/linuxMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -7,7 +7,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/macosMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/macosMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -7,7 +7,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/annotations/src/windowsMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
+++ b/tools/annotations/src/windowsMain/kotlin/org/godotengine/kotlin/annotation/Register.kt
@@ -7,7 +7,6 @@ import godot.registration.RPCMode
 @Retention(AnnotationRetention.RUNTIME)
 actual annotation class RegisterProperty(
         val visibleInEditor: Boolean,
-        val defaultValue: String,
         val rpcMode: RPCMode = RPCMode.Disabled,
         val propertyHint: PropertyHint = PropertyHint.None,
         val hintString: String = ""

--- a/tools/entry-generator/build.gradle.kts
+++ b/tools/entry-generator/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     compileOnly(project(":tools:annotations"))
     compileOnly(project(":tools:annotations-internal"))
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable") //used for class analisation without reflection
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler") //used for class analisation without reflection
     implementation("de.jensklingenberg:mpapt-runtime:${Dependencies.mpaptVersion}")
     implementation("com.squareup:kotlinpoet:${Dependencies.kotlinPoetVersion}")
 }

--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/FunctionElementExtension.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/FunctionElementExtension.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.godotengine.kotlin.entrygenerator.utils.castFromRawMemory
 import org.godotengine.kotlin.entrygenerator.utils.hasVarargParameter
+import org.godotengine.kotlin.entrygenerator.utils.isPrimitive
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
@@ -55,7 +56,11 @@ private fun CallableMemberDescriptor.getBridgeFunctionBody(fullClassName: String
             arguments.append("arg$parameterIndex")
         } else {
             varargSanityCheck(parameterIndex)
-            bridgeFunctionBodyBuilder.addStatement("val·arg$parameterIndex·=·Array(numArgs·-·${parameterIndex})·{·i·->·${this.valueParameters[parameterIndex].varargElementType?.castFromRawMemory("args[i·+·${parameterIndex}]!!")}·}")
+            var statementString = "val·arg$parameterIndex·=·Array(numArgs·-·${parameterIndex})·{·i·->·${this.valueParameters[parameterIndex].varargElementType?.castFromRawMemory("args[i·+·${parameterIndex}]!!")}·}"
+            if (this.valueParameters[parameterIndex].varargElementType?.toString()?.isPrimitive() == true) { //is a primitive data type. Thus it has to be converted to a primitive array
+               statementString = "$statementString.to${this.valueParameters[parameterIndex].varargElementType}Array()"
+            }
+            bridgeFunctionBodyBuilder.addStatement(statementString)
 
             if (parameterIndex != 0) {
                 arguments.append(",·")

--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/FunctionElementExtension.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/FunctionElementExtension.kt
@@ -47,7 +47,7 @@ private fun CallableMemberDescriptor.getBridgeFunctionBody(fullClassName: String
     val arguments = StringBuilder()
     this.valueParameters.forEachIndexed { parameterIndex, valueParameterDescriptor ->
         if (!valueParameterDescriptor.isVararg) {
-            bridgeFunctionBodyBuilder.addStatement("val·arg$parameterIndex·=·${valueParameterDescriptor.type.toString().castFromRawMemory("args[$parameterIndex]!!")}")
+            bridgeFunctionBodyBuilder.addStatement("val·arg$parameterIndex·=·${valueParameterDescriptor.type.castFromRawMemory("args[$parameterIndex]!!")}")
 
             if (parameterIndex != 0) {
                 arguments.append(",·")
@@ -55,7 +55,7 @@ private fun CallableMemberDescriptor.getBridgeFunctionBody(fullClassName: String
             arguments.append("arg$parameterIndex")
         } else {
             varargSanityCheck(parameterIndex)
-            bridgeFunctionBodyBuilder.addStatement("val·arg$parameterIndex·=·Array(numArgs·-·${parameterIndex})·{·i·->·${this.valueParameters[parameterIndex].varargElementType?.toString()?.castFromRawMemory("args[i·+·${parameterIndex}]!!")}·}")
+            bridgeFunctionBodyBuilder.addStatement("val·arg$parameterIndex·=·Array(numArgs·-·${parameterIndex})·{·i·->·${this.valueParameters[parameterIndex].varargElementType?.castFromRawMemory("args[i·+·${parameterIndex}]!!")}·}")
 
             if (parameterIndex != 0) {
                 arguments.append(",·")

--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/PropertyElementExtension.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/PropertyElementExtension.kt
@@ -56,7 +56,7 @@ private fun Element.PropertyElement.generatePropertySetterFunctionBinding(index:
 
 private fun Element.PropertyElement.generateDefaultValueGetter(index: Int): FunSpec {
     if (this.propertyDescriptor.isLateInit) {
-        throw IllegalStateException("The property ${this.propertyDescriptor.fqNameSafe} you annotated with @RegisterProperty is a lateinit var. You can only register properties with have a default value!\nEx: var myProperty = false")
+        throw IllegalStateException("The property ${this.propertyDescriptor.fqNameSafe} you annotated with @RegisterProperty is a lateinit var. You can only register properties which have a default value!\nEx: var myProperty = false")
     }
     if (!this.propertyDescriptor.type.toString().isCoreType() && (!this.propertyDescriptor.type.toString().isPrimitive() && !this.propertyDescriptor.type.asFqString().startsWith("kotlin"))) { //TODO: Implement support for curom classes after https://github.com/utopia-rise/godot-kotlin/issues/55 is done
         throw IllegalStateException("The property ${this.propertyDescriptor.fqNameSafe} you annotated with @RegisterProperty is a custom type ${this.propertyDescriptor.type}! This is not supported at the moment. Please export a godot or primitive type.")

--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/PropertyElementExtension.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/generator/PropertyElementExtension.kt
@@ -58,7 +58,7 @@ private fun Element.PropertyElement.generateDefaultValueGetter(index: Int): FunS
     if (this.propertyDescriptor.isLateInit) {
         throw IllegalStateException("The property ${this.propertyDescriptor.fqNameSafe} you annotated with @RegisterProperty is a lateinit var. You can only register properties with have a default value!\nEx: var myProperty = false")
     }
-    if (!this.propertyDescriptor.type.toString().isCoreType() && (!this.propertyDescriptor.type.toString().isPrimitive() && !this.propertyDescriptor.type.asFqString().startsWith("kotlin"))) {
+    if (!this.propertyDescriptor.type.toString().isCoreType() && (!this.propertyDescriptor.type.toString().isPrimitive() && !this.propertyDescriptor.type.asFqString().startsWith("kotlin"))) { //TODO: Implement support for curom classes after https://github.com/utopia-rise/godot-kotlin/issues/55 is done
         throw IllegalStateException("The property ${this.propertyDescriptor.fqNameSafe} you annotated with @RegisterProperty is a custom type ${this.propertyDescriptor.type}! This is not supported at the moment. Please export a godot or primitive type.")
     }
 

--- a/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/utils/Casts.kt
+++ b/tools/entry-generator/src/main/kotlin/org/godotengine/kotlin/entrygenerator/utils/Casts.kt
@@ -1,5 +1,9 @@
 package org.godotengine.kotlin.entrygenerator.utils
 
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.asSimpleType
+
 
 fun String.castToVariant(value: String): String {
     return "Variant($value)"
@@ -43,7 +47,7 @@ fun String.isCoreType(): Boolean {
 }
 
 
-fun String.castFromRawMemory(value: String): String {
+fun KotlinType.castFromRawMemory(value: String): String {
     return this.castFromVariant("godot.core.Variant($value)")
 }
 
@@ -53,7 +57,19 @@ fun String.castFromVariant(value: String): String {
         return value
     if (this.isCoreType() || this.isPrimitive())
         return "$value.to$this()"
-    return "godot.$this($value)"
+    return "$this($value)"
+}
+
+fun KotlinType.castFromVariant(value: String): String {
+    if (this.toString() == "Variant")
+        return value
+    if (this.toString().isCoreType() || this.toString().isPrimitive())
+        return "$value.to$this()"
+    return "${this.asFqString()}($value)"
+}
+
+fun KotlinType.asFqString(): String {
+    return this.asSimpleType().getJetTypeFqName(false)
 }
 
 

--- a/tools/godot-annotation-processor/build.gradle.kts
+++ b/tools/godot-annotation-processor/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation("de.jensklingenberg:mpapt-runtime:${Dependencies.mpaptVersion}")
     implementation("com.squareup:kotlinpoet:${Dependencies.kotlinPoetVersion}")
 
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable")
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler")
     compileOnly("com.google.auto.service:auto-service:${Dependencies.googleAutoServiceVersion}")
     kapt("com.google.auto.service:auto-service:${Dependencies.googleAutoServiceVersion}")
 }

--- a/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/subplugin/KotlinGodotSubplugin.kt
+++ b/tools/godot-gradle-plugin/src/main/kotlin/org/godotengine/kotlin/gradleplugin/subplugin/KotlinGodotSubplugin.kt
@@ -29,12 +29,12 @@ class KotlinGodotSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
             groupId = "org.godotengine.kotlin",
             artifactId = "kotlin-compiler-plugin",
-            version = "0.1.0-3.2" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
+            version = "0.1.1-3.2" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
     )
 
     override fun getNativeCompilerPluginArtifact() = SubpluginArtifact(
             groupId = "org.godotengine.kotlin",
             artifactId = "kotlin-compiler-native-plugin",
-            version = "0.1.0-3.2" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
+            version = "0.1.1-3.2" // remember to bump this version in conjunction with the version in Dependencies from buildSrc
     )
 }

--- a/tools/kotlin-compiler-native-plugin/build.gradle.kts
+++ b/tools/kotlin-compiler-native-plugin/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(project(":tools:godot-annotation-processor"))
     implementation("de.jensklingenberg:mpapt-runtime:${Dependencies.mpaptVersion}")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler")
+    implementation("org.jetbrains.kotlin:kotlin-compiler")
     compileOnly("com.google.auto.service:auto-service:${Dependencies.googleAutoServiceVersion}")
     kapt("com.google.auto.service:auto-service:${Dependencies.googleAutoServiceVersion}")
 }


### PR DESCRIPTION
This resolves #53.
This improves the default value registration for properties by leveraging the psi system to read the default value from code.
A user can now write:
```
@RegisterProperty(true)
var playerBodyNodePath = NodePath("Entities/Player/PlayerBody")
```
To register properties. The default value will in this example be `godot.core.NodePath("Entities/Player/PlayerBody")`.

Also this removes the possibility of defining default values for signals.
This is done because it didn't work in the first place and it seems not supported anymore anyways. I found no way to make it work and the cpp bindings for example don't seem to support it either. The same can be achieved anyways through binds in the `connect` method.
I someone has an idea of how tho make this work, I'm open for suggestions.
What i tried:
- Passing the individual default arguments one by one to the vararg `default_args` in the `register_signal` function.
- Passing all of them together to the `default_arg` parameter as a GDArray

Both ways if the signal was emitted with no arguments, the `args` value we get from godot is null.

I opted for removing this feature as i also didn't find it in the cpp binding, nor did i find any sort of documentation about it.