### PR TITLE
Implement registration annotations and temporary `RPCMode` enum

### DIFF
--- a/godot-kotlin/godot-library/build.gradle.kts
+++ b/godot-kotlin/godot-library/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
 }
@@ -15,7 +17,7 @@ kotlin {
 
     val nativeMain = sourceSets.create("nativeMain")
 
-    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+    targets.withType<KotlinNativeTarget> {
         compilations.getByName("main").defaultSourceSet { dependsOn(nativeMain) }
     }
 }

--- a/godot-kotlin/godot-library/build.gradle.kts
+++ b/godot-kotlin/godot-library/build.gradle.kts
@@ -1,3 +1,21 @@
 plugins {
     kotlin("multiplatform")
 }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+//TODO: this needs to be properly configured! This is just a basic setup to be able to implement the annotations
+kotlin {
+    linuxX64()
+    mingwX64()
+    macosX64()
+
+    val nativeMain = sourceSets.create("nativeMain")
+
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        compilations.getByName("main").defaultSourceSet { dependsOn(nativeMain) }
+    }
+}

--- a/godot-kotlin/godot-library/build.gradle.kts
+++ b/godot-kotlin/godot-library/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
     kotlin("multiplatform")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 //TODO: this needs to be properly configured! This is just a basic setup to be able to implement the annotations
 kotlin {
     linuxX64()

--- a/godot-kotlin/godot-library/gradle.properties
+++ b/godot-kotlin/godot-library/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RegisterAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RegisterAnnotation.kt
@@ -1,0 +1,24 @@
+package godot.annotation
+
+import godot.registration.RPCMode
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegisterClass
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegisterProperty(
+    val visibleInEditor: Boolean = false,
+    val rpcMode: RPCMode = RPCMode.Disabled
+)
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegisterFunction(
+    val rpcMode: RPCMode = RPCMode.Disabled
+)
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegisterSignal

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/RPCMode.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/RPCMode.kt
@@ -2,13 +2,13 @@ package godot.registration
 
 //TODO: temporary enum class! Needs to be properly implemented! Implementation was done to be able to implement register annotations
 enum class RPCMode {
-    Disabled,
-    Remote,
-    Sync,
-    Master,
-    Slave,
-    Puppet,
-    RemoteSync,
-    MasterSync,
-    PuppetSync
+    DISABLED,
+    REMOTE,
+    SYNC,
+    MASTER,
+    SLAVE,
+    PUPPET,
+    REMOTE_SYNC,
+    MASTER_SYNC,
+    PUPPET_SYNC
 }

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/RPCMode.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/RPCMode.kt
@@ -1,0 +1,14 @@
+package godot.registration
+
+//TODO: temporary enum class! Needs to be properly implemented! Implementation was done to be able to implement register annotations
+enum class RPCMode {
+    Disabled,
+    Remote,
+    Sync,
+    Master,
+    Slave,
+    Puppet,
+    RemoteSync,
+    MasterSync,
+    PuppetSync
+}


### PR DESCRIPTION
The RPCMode enum needs to be properly implemented later on.
It was just implemented so it can be added as an argument to
the annotations.

Also the build gradle for the `godot-library` needs proper implementation once the development starts there.

This resolves #68 