### PR TITLE
Implement rpc annotations

### DIFF
--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RpcAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RpcAnnotation.kt
@@ -1,0 +1,33 @@
+package godot.annotation
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Remote
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Disabled
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Sync
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Master
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Puppet
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RemoteSync
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MasterSync
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PuppetSync


### PR DESCRIPTION
This should be merged after #78 .

These are the RPCMode annotations a user can use instead of the RPCMode enum argument inside the `@RegisterProperty` and the `@RegisterFunction` annotations.

Resolves #70 .