### PR TITLE
Implement property hint annotations

### DIFF
--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -77,20 +77,6 @@ annotation class Flags
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Layers2DPhysics
-
-/**
- * Can only be used on Int properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class Layers3DPhysics
-
-/**
- * Can only be used on Int properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
 annotation class Layers2DRender
 
 /**
@@ -98,7 +84,21 @@ annotation class Layers2DRender
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
+annotation class Layers2DPhysics
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
 annotation class Layers3DRender
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Layers3DPhysics
 
 /**
  * Can only be used on String and File properties!

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -10,6 +10,34 @@ We should move that to the idea plugin at some point in time to provide IDE help
  */
 
 /**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IntRange(val start: Int, val end: Int, val step: Int = -1, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Float properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FloatRange(val start: Float, val end: Float, val step: Float = -1f, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DoubleRange(val start: Double, val end: Double, val step: Double = -1.0, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Float and Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExpRange(val start: Float, val end: Float, val step: Float = -1f)
+
+/**
  * This property hint is optional!
  *
  * A Enum that is visible to the editor is always marked as PROPERTY_HINT_ENUM if not defined otherwise
@@ -22,6 +50,20 @@ We should move that to the idea plugin at some point in time to provide IDE help
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class EnumTypeHint(val enumerateAsInt: Boolean = false)
+
+/**
+ * Can only be used on Float and Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExpEasing(val attenuation: Boolean = false, val inout: Boolean = true)
+
+/**
+ * Can only be used on Float and Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Lenght(val lenght: Int = -1)
 
 /**
  * Can only be used on Map<Enum, Boolean> properties!
@@ -59,46 +101,25 @@ annotation class Layers2DRender
 annotation class Layers3DRender
 
 /**
- * Can only be used on Int properties!
+ * Can only be used on String and File properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ObjectId
+annotation class File(vararg val extensions: String = [], val global: Boolean = false)
 
 /**
- * Can only be used on Int properties!
+ * Can only be used on String properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class IntRange(val start: Int, val end: Int, val step: Int = -1, val or: Range = Range.NONE)
+annotation class Dir(val global: Boolean = false)
 
 /**
- * Can only be used on Float properties!
+ * Can only be used on properties that derive from GodotResource!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class FloatRange(val start: Float, val end: Float, val step: Float = -1f, val or: Range = Range.NONE)
-
-/**
- * Can only be used on Double properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class DoubleRange(val start: Double, val end: Double, val step: Double = -1.0, val or: Range = Range.NONE)
-
-/**
- * Can only be used on Float and Double properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class ExpEasing(val attenuation: Boolean = false, val inout: Boolean = true)
-
-/**
- * Can only be used on Float and Double properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class ExpRange(val start: Float, val end: Float, val step: Float = -1f, val or: Range = Range.NONE)
+annotation class ResourceType(vararg val inherits: KClass<out GodotResource> = [GodotResource::class])
 
 /**
  * Can only be used on String properties!
@@ -108,51 +129,53 @@ annotation class ExpRange(val start: Float, val end: Float, val step: Float = -1
 annotation class MultilineText
 
 /**
- * This property hint is ignored! It's here for completion sake and match parity with godot's export hints.
- *
- * A String that is visible to the editor is always marked as PROPERTY_HINT_TYPE_STRING if not defined otherwise
- * through another PropertyTypeHintAnnotation
- *
  * Can only be used on String properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class StringTypeHint
+annotation class PlaceHolderText
+
+/**
+ * Can only be used on Color properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ColorNoAlpha
+
+/**
+ * Can only be used on Image properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ImageCompressLossy
+
+/**
+ * Can only be used on Image properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ImageCompressLossLess
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ObjectId
 
 /**
  * Can only be used on String properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Dir
+annotation class TypeString(val baseTypeAsString: String)
 
 /**
- * Can only be used on String and File properties!
+ * Can only be used on NodePath properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class File(vararg val extensions: String = [])
-
-/**
- * Can only be used on String and File properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class SaveFile(vararg val extensions: String = [])
-
-/**
- * Can only be used on String and File properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class GlobalDir
-
-/**
- * Can only be used on String and File properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class GlobalFile(vararg val extensions: String = [])
+annotation class NodePathToEditedNode
 
 /**
  * Can only be used on String properties!
@@ -210,26 +233,9 @@ annotation class PropertyOfInstance
 @Retention(AnnotationRetention.RUNTIME)
 annotation class PropertyOfScript
 
-/**
- * Can only be used on String properties!
- */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class PlaceHolderText
-
-/**
- * Can only be used on Color properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class ColorNoAlpha
-
-/**
- * Can only be used on NodePath properties!
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class NodePathToEditedNode
+annotation class ObjectTooBig
 
 /**
  * Can only be used on NodePath properties!
@@ -239,8 +245,15 @@ annotation class NodePathToEditedNode
 annotation class NodePathValidTypes
 
 /**
- * Can only be used on properties that derive from GodotResource!
+ * Can only be used on String and File properties!
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ResourceType(vararg val inherits: KClass<out GodotResource> = [GodotResource::class])
+annotation class SaveFile(vararg val extensions: String = [])
+
+/**
+ * Can only be used on String and File properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Max

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -1,0 +1,246 @@
+package godot.annotation
+
+import godot.core.GodotResource
+import godot.registration.Range
+import kotlin.reflect.KClass
+
+/*
+All type checks will happen at the entry-generator at the moment.
+We should move that to the idea plugin at some point in time to provide IDE help and not just compilation errors.
+ */
+
+/**
+ * This property hint is optional!
+ *
+ * A Enum that is visible to the editor is always marked as PROPERTY_HINT_ENUM if not defined otherwise
+ * through another PropertyTypeHintAnnotation. It then will enumerate using strings.
+ *
+ * You only have to use this annotation if you want to enumerate enums with ints in the editor.
+ *
+ * Can only be used on Enum properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EnumTypeHint(val enumerateAsInt: Boolean = false)
+
+/**
+ * Can only be used on Map<Enum, Boolean> properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Flags
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Layers2DPhysics
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Layers3DPhysics
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Layers2DRender
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Layers3DRender
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ObjectId
+
+/**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IntRange(val start: Int, val end: Int, val step: Int = -1, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Float properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FloatRange(val start: Float, val end: Float, val step: Float = -1f, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DoubleRange(val start: Double, val end: Double, val step: Double = -1.0, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on Float and Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExpEasing(val attenuation: Boolean = false, val inout: Boolean = true)
+
+/**
+ * Can only be used on Float and Double properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExpRange(val start: Float, val end: Float, val step: Float = -1f, val or: Range = Range.NONE)
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MultilineText
+
+/**
+ * This property hint is ignored! It's here for completion sake and match parity with godot's export hints.
+ *
+ * A String that is visible to the editor is always marked as PROPERTY_HINT_TYPE_STRING if not defined otherwise
+ * through another PropertyTypeHintAnnotation
+ *
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class StringTypeHint
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Dir
+
+/**
+ * Can only be used on String and File properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class File(vararg val extensions: String = [])
+
+/**
+ * Can only be used on String and File properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SaveFile(vararg val extensions: String = [])
+
+/**
+ * Can only be used on String and File properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class GlobalDir
+
+/**
+ * Can only be used on String and File properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class GlobalFile(vararg val extensions: String = [])
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MethodOfVariantType
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MethodOfBaseType
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MethodOfInstance
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MethodOfScript
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PropertyOfVariantType
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PropertyOfBaseType
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PropertyOfInstance
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PropertyOfScript
+
+/**
+ * Can only be used on String properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PlaceHolderText
+
+/**
+ * Can only be used on Color properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ColorNoAlpha
+
+/**
+ * Can only be used on NodePath properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class NodePathToEditedNode
+
+/**
+ * Can only be used on NodePath properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class NodePathValidTypes
+
+/**
+ * Can only be used on properties that derive from GodotResource!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ResourceType(vararg val inherits: KClass<out GodotResource> = [GodotResource::class])

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -252,6 +252,13 @@ annotation class NodePathValidTypes
 annotation class SaveFile(vararg val extensions: String = [])
 
 /**
+ * Can only be used on Int properties!
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IntIsObjectId
+
+/**
  * Can only be used on String and File properties!
  */
 @Target(AnnotationTarget.PROPERTY)

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RegisterAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/annotation/RegisterAnnotation.kt
@@ -4,7 +4,7 @@ import godot.registration.RPCMode
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class RegisterClass
+annotation class RegisterClass(val isTool: Boolean = false)
 
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/core/GodotResource.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/core/GodotResource.kt
@@ -1,0 +1,5 @@
+package godot.core
+
+//TODO: this needs to be properly implemented. It's just here for the implementation of the PropertyTypeHintAnnotations
+class GodotResource {
+}

--- a/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/Range.kt
+++ b/godot-kotlin/godot-library/src/nativeMain/kotlin/godot/registration/Range.kt
@@ -1,0 +1,7 @@
+package godot.registration
+
+enum class Range {
+    NONE,
+    OR_GREATER,
+    OR_LESSER
+}


### PR DESCRIPTION
I hope i have catched all property type hint's with the correct arguments.

I looked at the godot source code [here](https://github.com/godotengine/godot/blob/5f1107aa30295e686be6f41cb6d17fc2cff1e036/editor/editor_properties.cpp) to see which type hints exist, on what types they apply and what arguments they might take. Also a helpful link to the godot documentation about exporting variables [here](http://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_exports.html#doc-gdscript-exports).

A note. As far as I know, one cannot define for an annotation on what property types a user can apply those. So i guess for now we will have to make those checks in the entry-generator at compile time. So we can only prevent the user from adding a annotation that belongs to an property with type Int to a property with type String at compile time.

In the future the goal IMHO should be to make those checks inside the idea plugin to provide better IDE support.

Resolves #69 .