### PR TITLE
Implement annotation-processor

### DIFF
--- a/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -1,0 +1,3 @@
+object DependenciesVersions {
+    const val mpaptVersion: String = "0.8.4"
+}

--- a/entry-generation/godot-annotation-processor/build.gradle.kts
+++ b/entry-generation/godot-annotation-processor/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation("de.jensklingenberg:mpapt-runtime:${DependenciesVersions.mpaptVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
+}

--- a/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -9,9 +9,10 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.platform.TargetPlatform
 import java.lang.instrument.IllegalClassFormatException
-import java.nio.file.Paths
 
-class GodotAnnotationProcessor : AbstractProcessor() {
+class GodotAnnotationProcessor(
+    private val entryGenerationOutputDir: String
+) : AbstractProcessor() {
     override fun getSupportedAnnotationTypes(): Set<String> =
         setOf(
             "godot.annotation.RegisterClass",
@@ -94,13 +95,5 @@ class GodotAnnotationProcessor : AbstractProcessor() {
 
     override fun processingOver() {
         //TODO: entry generation
-    }
-
-    /**
-     * Returns the path as a String to which the generated code should be written
-     * @return directory path to where the generated code should be written to as a String
-     */
-    private fun getKaptGeneratedDirectory(): String {
-        return "${Paths.get("").toAbsolutePath()}/build/godot/entries"
     }
 }

--- a/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -1,0 +1,106 @@
+package godot.annotation.processor
+
+import de.jensklingenberg.mpapt.model.AbstractProcessor
+import de.jensklingenberg.mpapt.model.Element
+import de.jensklingenberg.mpapt.model.RoundEnvironment
+import de.jensklingenberg.mpapt.utils.KotlinPlatformValues
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.platform.TargetPlatform
+import java.lang.instrument.IllegalClassFormatException
+import java.nio.file.Paths
+
+class GodotAnnotationProcessor : AbstractProcessor() {
+    override fun getSupportedAnnotationTypes(): Set<String> =
+        setOf(
+            "godot.annotation.RegisterClass",
+            "godot.annotation.RegisterProperty",
+            "godot.annotation.RegisterFunction",
+            "godot.annotation.RegisterSignal"
+        )
+
+    override fun isTargetPlatformSupported(platform: TargetPlatform): Boolean {
+        return when (val targetName = platform.first().platformName) {
+            KotlinPlatformValues.JS -> false
+            KotlinPlatformValues.JVM -> false
+            KotlinPlatformValues.NATIVE -> true
+            else -> {
+                log("Unknown configured target: $targetName")
+                false
+            }
+        }
+    }
+
+    private val classes: MutableSet<ClassDescriptor> = mutableSetOf()
+    private val properties: MutableSet<PropertyDescriptor> = mutableSetOf()
+    private val functions: MutableSet<FunctionDescriptor> = mutableSetOf()
+    private val signals: MutableSet<PropertyDescriptor> = mutableSetOf()
+
+    override fun process(roundEnvironment: RoundEnvironment) {
+        classes.addAll(
+            roundEnvironment
+                .getElementsAnnotatedWith("godot.annotation.RegisterClass")
+                .map { it as Element.ClassElement }
+                .map { it.classDescriptor }
+        )
+
+        properties.addAll(
+            roundEnvironment
+                .getElementsAnnotatedWith("godot.annotation.RegisterProperty")
+                .map { it as Element.PropertyElement }
+                .map { it.propertyDescriptor }
+        )
+
+        functions.addAll(
+            roundEnvironment
+                .getElementsAnnotatedWith("godot.annotation.RegisterFunction")
+                .map { it as Element.FunctionElement }
+                .map { it.func }
+        )
+
+        signals.addAll(
+            roundEnvironment
+                .getElementsAnnotatedWith("godot.annotation.RegisterSignal")
+                .map { it as Element.PropertyElement }
+                .map { it.propertyDescriptor }
+        )
+
+        performSanityChecks()
+    }
+
+    private fun performSanityChecks() {
+        classes.forEach {
+            if (it.constructors.size > 1) {
+                throw IllegalClassFormatException("A Class annotated with \"@RegisterClass\" can only have a default constructor!\nBut ${it.name} contains ${it.constructors.size} constructors")
+            }
+        }
+        functions.forEach {
+            if (!classes.contains(it.containingDeclaration)) {
+                throw Exception("${it.containingDeclaration.name.asString()} contains a registered function: ${it.name} but is not annotated with @RegisterClass! Classes containing functions which are registered, also have to be registered!")
+            }
+        }
+        properties.forEach {
+            if (!classes.contains(it.containingDeclaration)) {
+                throw Exception("${it.containingDeclaration.name.asString()} contains a registered property: ${it.name} but is not annotated with @RegisterClass! Classes containing properties which are registered, also have to be registered!")
+            }
+        }
+        signals.forEach {
+            if (!classes.contains(it.containingDeclaration)) {
+                throw Exception("${it.containingDeclaration.name.asString()} contains a signal: ${it.name} but is not annotated with @RegisterClass! Classes containing signals, also have to be registered!")
+            }
+        }
+    }
+
+    override fun processingOver() {
+        //TODO: entry generation
+    }
+
+    /**
+     * Returns the path as a String to which the generated code should be written
+     * @return directory path to where the generated code should be written to as a String
+     */
+    private fun getKaptGeneratedDirectory(): String {
+        return "${Paths.get("").toAbsolutePath()}/build/godot/entries"
+    }
+}

--- a/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/RegisterAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/RegisterAnnotation.kt
@@ -2,6 +2,11 @@ package godot.annotation
 
 import godot.registration.RPCMode
 
+/*
+If a change is made to a annotation name or the package path has changed,
+remember to also change it here: GodotAnnotationProcessor!
+*/
+
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class RegisterClass(val isTool: Boolean = false)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ subdir("plugins") {
     include("godot-gradle-plugin")
 }
 
-subdir("entry-generator") {
-    include("godot-entry-generator")
+subdir("entry-generation") {
+    include("godot-annotation-processor")
 }
 
 // TODO: remove this once the samples are not using the local artifacts


### PR DESCRIPTION
This implements the annotation processor.

It cannot be tested at the moment as it does not function without the compiler plugin. But as not much has changed to the last annotation processor, I have no reason to believe it's not working.

Closes #71 