### PR TITLE
Update mpapt to release version

### DIFF
--- a/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -1,4 +1,4 @@
 object DependenciesVersions {
-    const val mpaptVersion: String = "0.8.5-SNAPSHOT"
+    const val mpaptVersion: String = "0.8.5"
     const val shadowJarPluginVersion: String = "5.0.0"
 }


### PR DESCRIPTION
I don't have the snapshot version locally so the builds fails for me. Release build is already available: https://github.com/Foso/MpApt/commit/005af4a6a37b44aa161789503ef4a767fd4855fa