### PR TITLE
Refactor hintType and hintString generation and implement coreType re…

### DIFF
--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/exceptions/WrongAnnotationUsageException.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/exceptions/WrongAnnotationUsageException.kt
@@ -1,0 +1,14 @@
+package godot.entrygenerator.exceptions
+
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class WrongAnnotationUsageException(
+    propertyDescriptor: PropertyDescriptor,
+    propertyHintAnnotation: AnnotationDescriptor?,
+    effectiveType: String? = null
+) : Exception(
+    "You annotated ${propertyDescriptor.fqNameSafe} with @${propertyHintAnnotation?.fqName?.asString()?.split(".")
+        ?.last()} which ${if (effectiveType != null) "is only applicable to properties of type $effectiveType" else "cannot be applied on properties of type ${propertyDescriptor.type}"}"
+)

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
@@ -1,0 +1,37 @@
+package godot.entrygenerator.extension
+
+import org.jetbrains.kotlin.types.KotlinType
+
+
+fun KotlinType.isCoreType(): Boolean {
+    return coreTypes.contains(this.toString())
+}
+
+private val coreTypes = listOf(
+    "GDArray",
+    "Basis",
+    "Color",
+    "Dictionary",
+    "GodotError",
+    "NodePath",
+    "Plane",
+    "PoolByteArray",
+    "PoolIntArray",
+    "PoolRealArray",
+    "PoolStringArray",
+    "PoolVector2Array",
+    "PoolVector3Array",
+    "PoolColorArray",
+    "PoolIntArray",
+    "PoolRealArray",
+    "Quat",
+    "Rect2",
+    "AABB",
+    "RID",
+    "String",
+    "Transform",
+    "Transform2D",
+    "Variant",
+    "Vector2",
+    "Vector3"
+)

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/CoreTypeRegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/CoreTypeRegistrationValuesHandler.kt
@@ -1,0 +1,47 @@
+package godot.entrygenerator.generator.provider
+
+import com.squareup.kotlinpoet.ClassName
+import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.resolve.BindingContext
+
+class CoreTypeRegistrationValuesHandler(
+    propertyDescriptor: PropertyDescriptor,
+    bindingContext: BindingContext
+) : RegistrationValuesHandler(propertyDescriptor, bindingContext) {
+
+    override fun getPropertyTypeHint(): ClassName {
+
+        return when (propertyHintAnnotation?.fqName?.asString()) {
+            "godot.annotation.ColorNoAlpha" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_COLOR_NO_ALPHA")
+            //TODO: implement ResourceType
+            //TODO: implement ImageCompressLossy
+            //TODO: implement ImageCompressLossLess
+            //TODO: implement NodePathToEditedNode
+            //TODO: implement NodePathValidTypes
+            null -> ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_NONE")
+            else -> throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation)
+        }
+    }
+
+    override fun getHintString(): String {
+        return when (propertyHintAnnotation?.fqName?.asString()) {
+            "godot.annotation.ColorNoAlpha" -> getColorNoAlphaHintString()
+            //TODO: implement ResourceType
+            //TODO: implement ImageCompressLossy
+            //TODO: implement ImageCompressLossLess
+            //TODO: implement NodePathToEditedNode
+            //TODO: implement NodePathValidTypes
+            null -> ""
+            else -> throw IllegalStateException("Unknown annotation ${propertyHintAnnotation.fqName}")
+        }
+    }
+
+    private fun getColorNoAlphaHintString(): String {
+        if (propertyDescriptor.type.toString() != "Color") {
+            throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation, "Color")
+        }
+        return "" //hint string is empty for this typehint
+    }
+}

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/DefaultValueHandlerProvider.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/DefaultValueHandlerProvider.kt
@@ -1,5 +1,6 @@
 package godot.entrygenerator.generator.provider
 
+import godot.entrygenerator.extension.isCoreType
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -10,15 +11,22 @@ object DefaultValueHandlerProvider {
         propertyDescriptor: PropertyDescriptor,
         bindingContext: BindingContext
     ): RegistrationValuesHandler {
-        return when  {
+        return when {
             KotlinBuiltIns.isInt(propertyDescriptor.type)
                 || KotlinBuiltIns.isInt(propertyDescriptor.type)
                 || KotlinBuiltIns.isLong(propertyDescriptor.type)
                 || KotlinBuiltIns.isFloat(propertyDescriptor.type)
                 || KotlinBuiltIns.isDouble(propertyDescriptor.type)
                 || KotlinBuiltIns.isBoolean(propertyDescriptor.type)
-                || KotlinBuiltIns.isString(propertyDescriptor.type) -> PrimitiveRegistrationValuesHandler(propertyDescriptor, bindingContext)
+                || KotlinBuiltIns.isString(propertyDescriptor.type) -> PrimitiveRegistrationValuesHandler(
+                propertyDescriptor,
+                bindingContext
+            )
             propertyDescriptor.type.isEnum() -> EnumRegistrationValuesHandler(propertyDescriptor, bindingContext)
+            propertyDescriptor.type.isCoreType() -> CoreTypeRegistrationValuesHandler(
+                propertyDescriptor,
+                bindingContext
+            )
             else -> TODO()
         }
     }

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/PrimitiveRegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/PrimitiveRegistrationValuesHandler.kt
@@ -1,25 +1,198 @@
 package godot.entrygenerator.generator.provider
 
 import com.squareup.kotlinpoet.ClassName
-import godot.entrygenerator.extension.getPropertyHintAnnotation
-import godot.entrygenerator.mapper.PropertyHintTypeMapper
+import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.extension.getAnnotationValue
+import godot.entrygenerator.model.*
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.constants.StringValue
+import org.jetbrains.kotlin.utils.join
+import kotlin.reflect.KClass
 
 class PrimitiveRegistrationValuesHandler(
     propertyDescriptor: PropertyDescriptor,
     bindingContext: BindingContext
 ) : RegistrationValuesHandler(propertyDescriptor, bindingContext) {
     override fun getPropertyTypeHint(): ClassName {
-        return PropertyHintTypeMapper
-            .mapAnnotationDescriptorToPropertyTypeClassName(propertyDescriptor.getPropertyHintAnnotation())
+        return when (propertyHintAnnotation?.fqName?.asString()) {
+            "godot.annotation.IntRange", "godot.annotation.FloatRange", "godot.annotation.DoubleRange" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_RANGE")
+            "godot.annotation.ExpRange" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_EXP_RANGE")
+            "godot.annotation.ExpEasing" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_EXP_EASING")
+            "godot.annotation.Lenght" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_LENGHT")
+            "godot.annotation.Layers2DRender" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_LAYERS_2D_RENDER")
+            "godot.annotation.Layers2DPhysics" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_LAYERS_2D_PHYSICS")
+            "godot.annotation.Layers3DRender" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_LAYERS_3D_RENDER")
+            "godot.annotation.Layers3DPhysics" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_LAYERS_3D_PHYSICS")
+            "godot.annotation.File" ->
+                if (propertyHintAnnotation.getAnnotationValue(FILE_AND_DIR_ANNOTATION_GLOBAL_ARGUMENT, false)) {
+                    ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_GLOBAL_FILE")
+                } else {
+                    ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_FILE")
+                }
+            "godot.annotation.Dir" ->
+                if (propertyHintAnnotation.getAnnotationValue(FILE_AND_DIR_ANNOTATION_GLOBAL_ARGUMENT, false)) {
+                    ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_GLOBAL_DIR")
+                } else {
+                    ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_DIR")
+                }
+            "godot.annotation.MultilineText" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_MULTILINE_TEXT")
+            "godot.annotation.PlaceHolderText" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_PLACE_HOLDER_TEXT")
+            "godot.annotation.ObjectId" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_OBJECT_ID")
+            "godot.annotation.TypeString" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_TYPE_STRING")
+            "godot.annotation.MethodOfVariantType" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_METHOD_OF_VARIANT_TYPE")
+            "godot.annotation.MethodOfBaseType" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_METHOD_OF_BASE_TYPE")
+            "godot.annotation.MethodOfInstance" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_METHOD_OF_INSTANCE")
+            "godot.annotation.MethodOfScript" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_METHOD_OF_SCRIPT")
+            "godot.annotation.PropertyOfVariantType" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE")
+            "godot.annotation.PropertyOfBaseType" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_PROPERTY_OF_BASE_TYPE")
+            "godot.annotation.PropertyOfInstance" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_PROPERTY_OF_INSTANCE")
+            "godot.annotation.PropertyOfScript" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_PROPERTY_OF_SCRIPT")
+            "godot.annotation.SaveFile" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_SAVE_FILE")
+            "godot.annotation.IntIsObjectId" ->
+                ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_INT_IS_OBJECT_ID")
+            "godot.annotation.Max" -> ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_MAX")
+            null -> ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_NONE")
+            else -> throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation)
+        }
     }
 
     override fun getHintString(): String {
-        return PropertyHintTypeMapper
-            .mapAnnotationDescriptorToPropertyHintString(
-                propertyDescriptor,
-                propertyDescriptor.getPropertyHintAnnotation()
-            )
+        return when (propertyHintAnnotation?.fqName?.asString()) {
+            "godot.annotation.IntRange" ->
+                getRangeTypeHint(arrayOf(Int::class))
+            "godot.annotation.FloatRange" ->
+                getRangeTypeHint(arrayOf(Float::class))
+            "godot.annotation.DoubleRange" ->
+                getRangeTypeHint(arrayOf(Double::class))
+            "godot.annotation.ExpRange" ->
+                getRangeTypeHint(arrayOf(Float::class, Double::class))
+            "godot.annotation.ExpEasing" -> getExpEasingTypeHint()
+            "godot.annotation.Lenght" -> throw NotImplementedError("@Lenght annotation is not yet implemented") //getLengthTypeHint(annotationDescriptor, propertyDescriptor)
+            "godot.annotation.Layers2DRender" -> throw NotImplementedError("@Layers2DRender annotation is not yet implemented")
+            "godot.annotation.Layers2DPhysics" -> throw NotImplementedError("@Layers2DPhysics annotation is not yet implemented")
+            "godot.annotation.Layers3DRender" -> throw NotImplementedError("@Layers3DRender annotation is not yet implemented")
+            "godot.annotation.Layers3DPhysics" -> throw NotImplementedError("@Layers3DPhysics annotation is not yet implemented")
+            "godot.annotation.File", "godot.annotation.Dir" -> getFileOrDirTypeHint()
+            "godot.annotation.MultilineText" -> throw NotImplementedError("@MultilineText annotation is not yet implemented")
+            "godot.annotation.PlaceHolderText" -> throw NotImplementedError("@PlaceHolderText annotation is not yet implemented")
+            "godot.annotation.TypeString" -> throw NotImplementedError("@TypeString annotation is not yet implemented")
+            "godot.annotation.MethodOfVariantType" -> throw NotImplementedError("@MethodOfVariantType annotation is not yet implemented")
+            "godot.annotation.MethodOfBaseType" -> throw NotImplementedError("@MethodOfBaseType annotation is not yet implemented")
+            "godot.annotation.MethodOfInstance" -> throw NotImplementedError("@MethodOfInstance annotation is not yet implemented")
+            "godot.annotation.MethodOfScript" -> throw NotImplementedError("@MethodOfScript annotation is not yet implemented")
+            "godot.annotation.PropertyOfVariantType" -> throw NotImplementedError("@PropertyOfVariantType annotation is not yet implemented")
+            "godot.annotation.PropertyOfBaseType" -> throw NotImplementedError("@PropertyOfBaseType annotation is not yet implemented")
+            "godot.annotation.PropertyOfInstance" -> throw NotImplementedError("@PropertyOfInstance annotation is not yet implemented")
+            "godot.annotation.PropertyOfScript" -> throw NotImplementedError("@PropertyOfScript annotation is not yet implemented")
+            "godot.annotation.SaveFile" -> throw NotImplementedError("@SaveFile annotation is not yet implemented")
+            "godot.annotation.IntIsObjectId" -> throw NotImplementedError("@IntIsObjectId annotation is not yet implemented")
+            "godot.annotation.Max" -> throw NotImplementedError("@Max annotation is not yet implemented")
+            null -> ""
+            else -> throw IllegalStateException("Unknown annotation ${propertyHintAnnotation.fqName}")
+        }
+    }
+
+    private fun mapCompilerEnumRepresentationToClassName(enumRepresentation: Pair<ClassId, Name>): ClassName {
+        return ClassName(
+            enumRepresentation.first.asString().replace("/", ".").replace(".${enumRepresentation.second}", ""),
+            enumRepresentation.second.asString()
+        )
+    }
+
+    private fun getRangeTypeHint(expectedTypes: Array<KClass<*>>): String {
+        if (expectedTypes.map { it.toString() }.contains(propertyDescriptor.type.toString())) {
+            throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation, expectedTypes.toString())
+        }
+
+        val start = propertyHintAnnotation!!.getAnnotationValue(RANGE_ANNOTATION_START_ARGUMENT, -1)
+        val end = propertyHintAnnotation.getAnnotationValue(RANGE_ANNOTATION_END_ARGUMENT, -1)
+        val step = propertyHintAnnotation.getAnnotationValue(RANGE_ANNOTATION_STEP_ARGUMENT, -1)
+        val or = propertyHintAnnotation.getAnnotationValue(
+            RANGE_ANNOTATION_OR_ARGUMENT,
+            Pair(ClassId(FqName("godot.registration"), Name.identifier("Range")), Name.identifier("NONE"))
+        )
+        val orAsClassName = mapCompilerEnumRepresentationToClassName(or)
+
+        val argumentsForStringTemplate = mutableListOf<Any>()
+
+        argumentsForStringTemplate.add(start)
+        argumentsForStringTemplate.add(end)
+        if (step != -1) {
+            argumentsForStringTemplate.add(step)
+        }
+        if (orAsClassName.toString() != "godot.registration.Range.NONE") {
+            argumentsForStringTemplate.add(orAsClassName.toString().split(".").last().toLowerCase())
+        }
+
+        return join(argumentsForStringTemplate, ",")
+    }
+
+    private fun getExpEasingTypeHint(): String {
+        if (listOf(Float::class, Double::class).map { it.toString() }.contains(propertyDescriptor.type.toString())) {
+            throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation, "Floats and Doubles")
+        }
+
+        val attenuation = propertyHintAnnotation!!.getAnnotationValue(EXP_EASING_ANNOTATION_ATTENUATION_ARGUMENT, false)
+        val inout = propertyHintAnnotation.getAnnotationValue(EXP_EASING_ANNOTATION_INOUT_ARGUMENT, true)
+
+        val stringTemplateValues = when {
+            attenuation && inout -> "attenuation,inout"
+            attenuation -> "attenuation"
+            inout -> "inout"
+            else -> ""
+        }
+
+        return stringTemplateValues
+    }
+
+    private fun getLengthTypeHint(): String {
+        if (listOf(Float::class, Double::class).map { it.toString() }.contains(propertyDescriptor.type.toString())) {
+            throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation, "Floats and Doubles")
+        }
+
+        val length = propertyHintAnnotation!!.getAnnotationValue(LENGTH_ANNOTATION_LENGTH_ARGUMENT, -1)
+
+        return if (length != -1) {
+            "$length"
+        } else {
+            ""
+        }
+    }
+
+    private fun getFileOrDirTypeHint(): String {
+        if (propertyDescriptor.type.toString() != "String") {
+            throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation, "String")
+        }
+
+        val extensions = propertyHintAnnotation!!
+            .getAnnotationValue(FILE_AND_DIR_ANNOTATION_EXTENSIONS_ARGUMENT, ArrayList<StringValue>())
+            .map { it.value.replace("\"", "") }
+
+        return join(extensions, ",")
     }
 }

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/RegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/RegistrationValuesHandler.kt
@@ -2,6 +2,10 @@ package godot.entrygenerator.generator.provider
 
 import com.squareup.kotlinpoet.ClassName
 import godot.entrygenerator.extension.assignmentPsi
+import godot.entrygenerator.extension.getAnnotationValue
+import godot.entrygenerator.extension.getPropertyHintAnnotation
+import godot.entrygenerator.model.REGISTER_PROPERTY_ANNOTATION
+import godot.entrygenerator.model.REGISTER_PROPERTY_ANNOTATION_VISIBLE_IN_EDITOR_ARGUMENT
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.psi.*
@@ -16,8 +20,25 @@ abstract class RegistrationValuesHandler(
     val propertyDescriptor: PropertyDescriptor,
     val bindingContext: BindingContext
 ) {
+    internal val propertyHintAnnotation = propertyDescriptor.getPropertyHintAnnotation()
+
     abstract fun getPropertyTypeHint(): ClassName
     abstract fun getHintString(): String
+
+    init {
+        checkHintAnnotationUsage()
+    }
+
+    private fun checkHintAnnotationUsage() {
+        if (!propertyDescriptor.annotations.getAnnotationValue(
+                REGISTER_PROPERTY_ANNOTATION,
+                REGISTER_PROPERTY_ANNOTATION_VISIBLE_IN_EDITOR_ARGUMENT,
+                true
+            ) && propertyHintAnnotation != null
+        ) {
+            throw IllegalStateException("You added the type hint annotation ${propertyHintAnnotation.fqName} to the property ${propertyDescriptor.name}. But the @RegisterProperty annotation is either not present or the isVisibleInEditor flag is not set to true")
+        }
+    }
 
     fun getDefaultValue(): Pair<String, Array<Any>> {
         if (propertyDescriptor.isLateInit) {

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/mapper/PropertyHintTypeMapper.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/mapper/PropertyHintTypeMapper.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.types.typeUtil.isEnum
 import org.jetbrains.kotlin.utils.join
 import kotlin.reflect.KClass
 
+//TODO: remove this file. Still here for reference until all RegistrationValueHandler's are implemented
 object PropertyHintTypeMapper {
 
     fun mapAnnotationDescriptorToPropertyTypeClassName(annotationDescriptor: AnnotationDescriptor?): ClassName {

--- a/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -238,7 +238,7 @@ annotation class ColorNoAlpha
 //annotation class NodePathValidTypes
 
 /**
- * Can only be used on String and File properties!
+ * Can only be used on String properties!
  */
 //@Target(AnnotationTarget.PROPERTY)
 //@Retention(AnnotationRetention.RUNTIME)
@@ -252,7 +252,7 @@ annotation class ColorNoAlpha
 //annotation class IntIsObjectId
 
 /**
- * Can only be used on String and File properties!
+ * Can only be used on String properties!
  */
 //@Target(AnnotationTarget.PROPERTY)
 //@Retention(AnnotationRetention.RUNTIME)

--- a/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
+++ b/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
@@ -2,6 +2,7 @@ package example
 
 import godot.annotation.*
 import godot.core.Object
+import godot.core.Variant
 import godot.core.signal
 import godot.registration.RPCMode
 import godot.registration.Range
@@ -62,4 +63,7 @@ class TestingClass : Object() {
 
     @RegisterProperty
     var flag: Boolean = false
+
+    @RegisterProperty
+    var variantTest = Variant("test")
 }


### PR DESCRIPTION
this resolves #98 and enables default value generation and type hint generation for core types.

It also refactors the said generation to happen in the individual `RegistrationValueHandler`s rather than in one big `PropertyHintMapper` (file still exists thoug for reference until all `RegistrationValueHandler`s are implemented)