### PR TITLE
EntryRegistration: Implement GodotResource registration

### DIFF
--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
@@ -1,5 +1,6 @@
 package godot.entrygenerator.extension
 
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
@@ -9,10 +10,11 @@ fun KotlinType.isCoreType(): Boolean {
 }
 
 fun KotlinType.isResource(): Boolean {
-    return this.toString() == "GodotResource"
+    return this.getJetTypeFqName(false) == "godot.Resource"
         || this
         .supertypes()
-        .any { it.toString() == "GodotResource" }
+        .map { it.getJetTypeFqName(false) }
+        .any { it == "godot.Resource" }
 }
 
 private val coreTypes = listOf(

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/extension/KotlinTypeExt.kt
@@ -1,10 +1,18 @@
 package godot.entrygenerator.extension
 
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 
 fun KotlinType.isCoreType(): Boolean {
     return coreTypes.contains(this.toString())
+}
+
+fun KotlinType.isResource(): Boolean {
+    return this.toString() == "GodotResource"
+        || this
+        .supertypes()
+        .any { it.toString() == "GodotResource" }
 }
 
 private val coreTypes = listOf(

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/CoreTypeRegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/CoreTypeRegistrationValuesHandler.kt
@@ -15,7 +15,6 @@ class CoreTypeRegistrationValuesHandler(
         return when (propertyHintAnnotation?.fqName?.asString()) {
             "godot.annotation.ColorNoAlpha" ->
                 ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_COLOR_NO_ALPHA")
-            //TODO: implement ResourceType
             //TODO: implement ImageCompressLossy
             //TODO: implement ImageCompressLossLess
             //TODO: implement NodePathToEditedNode
@@ -28,7 +27,6 @@ class CoreTypeRegistrationValuesHandler(
     override fun getHintString(): String {
         return when (propertyHintAnnotation?.fqName?.asString()) {
             "godot.annotation.ColorNoAlpha" -> getColorNoAlphaHintString()
-            //TODO: implement ResourceType
             //TODO: implement ImageCompressLossy
             //TODO: implement ImageCompressLossLess
             //TODO: implement NodePathToEditedNode

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/DefaultValueHandlerProvider.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/DefaultValueHandlerProvider.kt
@@ -1,6 +1,7 @@
 package godot.entrygenerator.generator.provider
 
 import godot.entrygenerator.extension.isCoreType
+import godot.entrygenerator.extension.isResource
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -24,6 +25,10 @@ object DefaultValueHandlerProvider {
             )
             propertyDescriptor.type.isEnum() -> EnumRegistrationValuesHandler(propertyDescriptor, bindingContext)
             propertyDescriptor.type.isCoreType() -> CoreTypeRegistrationValuesHandler(
+                propertyDescriptor,
+                bindingContext
+            )
+            propertyDescriptor.type.isResource() -> ResourceRegistrationValuesHandler(
                 propertyDescriptor,
                 bindingContext
             )

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/ResourceRegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/ResourceRegistrationValuesHandler.kt
@@ -13,7 +13,7 @@ class ResourceRegistrationValuesHandler(
 
     override fun getDefaultValue(): Pair<String, Array<Any>> {
         if (!propertyDescriptor.isLateInit && isVisibleInEditor()) {
-            throw IllegalStateException("You initialized the property \"${propertyDescriptor.fqNameSafe}\". Properties of type GodotResource which are registered using the @RegisterProperty annotation and are visible in the editor are not allowed to have a default value. Use lateinit.")
+            throw IllegalStateException("You initialized the property \"${propertyDescriptor.fqNameSafe}\". Properties of type Resource which are registered using the @RegisterProperty annotation and are visible in the editor are not allowed to have a default value. Use lateinit.")
         }
         return super.getDefaultValue()
     }

--- a/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/ResourceRegistrationValuesHandler.kt
+++ b/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/provider/ResourceRegistrationValuesHandler.kt
@@ -1,0 +1,33 @@
+package godot.entrygenerator.generator.provider
+
+import com.squareup.kotlinpoet.ClassName
+import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class ResourceRegistrationValuesHandler(
+    propertyDescriptor: PropertyDescriptor,
+    bindingContext: BindingContext
+) : RegistrationValuesHandler(propertyDescriptor, bindingContext) {
+
+    override fun getDefaultValue(): Pair<String, Array<Any>> {
+        if (!propertyDescriptor.isLateInit && isVisibleInEditor()) {
+            throw IllegalStateException("You initialized the property \"${propertyDescriptor.fqNameSafe}\". Properties of type GodotResource which are registered using the @RegisterProperty annotation and are visible in the editor are not allowed to have a default value. Use lateinit.")
+        }
+        return super.getDefaultValue()
+    }
+
+    override fun getPropertyTypeHint(): ClassName {
+        return when (propertyHintAnnotation?.fqName?.asString()) {
+            //TODO: implement ResourceType
+            null -> ClassName("godot.gdnative.godot_property_hint", "GODOT_PROPERTY_HINT_NONE")
+            else -> throw WrongAnnotationUsageException(propertyDescriptor, propertyHintAnnotation)
+        }
+    }
+
+    override fun getHintString(): String {
+        //TODO: implement ResourceType
+        return ""
+    }
+}

--- a/godot-kotlin/godot-library/src/nativeGen/kotlin/godot/GodotResource.kt
+++ b/godot-kotlin/godot-library/src/nativeGen/kotlin/godot/GodotResource.kt
@@ -1,4 +1,4 @@
-package godot.core
+package godot
 
 //TODO: this needs to be properly implemented. It's just here for the implementation of the PropertyTypeHintAnnotations
 class GodotResource {

--- a/godot-kotlin/godot-library/src/nativeGen/kotlin/godot/Resource.kt
+++ b/godot-kotlin/godot-library/src/nativeGen/kotlin/godot/Resource.kt
@@ -1,5 +1,5 @@
 package godot
 
 //TODO: this needs to be properly implemented. It's just here for the implementation of the PropertyTypeHintAnnotations
-class GodotResource {
+class Resource {
 }

--- a/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
+++ b/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/annotation/PropertyTypeHintAnnotation.kt
@@ -108,7 +108,7 @@ annotation class File(vararg val extensions: String = [], val global: Boolean = 
 annotation class Dir(val global: Boolean = false)
 
 /**
- * Can only be used on properties that derive from GodotResource!
+ * Can only be used on properties that derive from Resource!
  */
 //@Target(AnnotationTarget.PROPERTY)
 //@Retention(AnnotationRetention.RUNTIME)

--- a/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
+++ b/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
@@ -1,6 +1,7 @@
 package example
 
 import godot.annotation.*
+import godot.core.GodotResource
 import godot.core.Object
 import godot.core.Variant
 import godot.core.signal
@@ -66,4 +67,13 @@ class TestingClass : Object() {
 
     @RegisterProperty
     var variantTest = Variant("test")
+
+    @RegisterProperty
+    lateinit var resourceVisibleInEditor: GodotResource
+
+    @RegisterProperty(false)
+    var resourceNotVisibleInEditor: GodotResource = GodotResource()
+
+//    @RegisterProperty // <- when visible in editor...
+//    var resourceVisibleInEditorButInitialized: GodotResource = GodotResource() // <- ...should fail!
 }

--- a/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
+++ b/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
@@ -1,7 +1,7 @@
 package example
 
+import godot.GodotResource
 import godot.annotation.*
-import godot.core.GodotResource
 import godot.core.Object
 import godot.core.Variant
 import godot.core.signal

--- a/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
+++ b/samples/mini-games/src/godotMain/kotlin/example/TestingClass.kt
@@ -1,6 +1,6 @@
 package example
 
-import godot.GodotResource
+import godot.Resource
 import godot.annotation.*
 import godot.core.Object
 import godot.core.Variant
@@ -69,11 +69,11 @@ class TestingClass : Object() {
     var variantTest = Variant("test")
 
     @RegisterProperty
-    lateinit var resourceVisibleInEditor: GodotResource
+    lateinit var resourceVisibleInEditor: Resource
 
     @RegisterProperty(false)
-    var resourceNotVisibleInEditor: GodotResource = GodotResource()
+    var resourceNotVisibleInEditor: Resource = Resource()
 
 //    @RegisterProperty // <- when visible in editor...
-//    var resourceVisibleInEditorButInitialized: GodotResource = GodotResource() // <- ...should fail!
+//    var resourceVisibleInEditorButInitialized: Resource = Resource() // <- ...should fail!
 }


### PR DESCRIPTION
This closes #99 and fixes the registration of properties which are not visible in the editor by not providing a default value for them.