### PR TITLE
Added RID and NodePath

### DIFF
--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
@@ -59,18 +59,28 @@ class NodePath : CoreType {
 
 
     //API
+    /**
+     * Get the node name indicated by idx (0 to get_name_count)
+     */
     fun getName(idx: Int): String {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_get_name)(it, idx)
         }.toKString()
+
     }
 
+    /**
+     * Get the number of node names which make up the path.
+     */
     fun getNameCount(): Int {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_get_name_count)(it)
         }
     }
 
+    /**
+     * Get the path’s property name, or an empty string if the path doesn’t have a property.
+     */
     fun getProperty(): String {
         return NodePath(
             callNative {
@@ -78,31 +88,46 @@ class NodePath : CoreType {
             }).toString()
     }
 
+    /**
+     * Get the resource name indicated by idx (0 to get_subname_count)
+     */
     fun getSubname(idx: Int): String {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
         }
     }
 
+    /**
+     * Get the number of resource names in the path.
+     */
     fun getSubnameCount(): Int {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_get_subname_count)(it)
         }
     }
 
+    /**
+     * Return true if the node path is absolute (not relative).
+     */
     fun isAbsolute(): Boolean {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_is_absolute)(it)
         }
     }
 
+    /**
+     * Return true if the node path is empty.
+     */
     fun isEmpty(): Boolean {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_is_empty)(it)
         }
     }
 
-    fun getConcatenatedSubnames() {
+    /**
+     *
+     */
+    fun getConcatenatedSubnames(): String {
         return callNative {
             checkNotNull(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
@@ -1,0 +1,137 @@
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package godot.core
+
+import godot.gdnative.*
+import kotlinx.cinterop.*
+import platform.posix.off_t
+
+
+class NodePath : CoreType {
+    //PROPERTIES
+    private lateinit var _handle: CValue<godot_node_path>
+
+    val path: String
+        get() {
+            return callNative {
+                checkNotNull(Godot.gdnative.godot_node_path_as_string)(it)
+            }.toKString()
+        }
+
+    //CONSTRUCTOR
+    constructor() {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
+        }
+    }
+
+    constructor(from: String) {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_new)(it, String().toGDString().ptr)
+        }
+    }
+
+    constructor(from: NodePath) {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_new)(it, String().toGDString().ptr)
+        }
+    }
+
+
+    internal constructor(native: CValue<godot_node_path>) {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_new_copy)(it, native.ptr)
+        }
+    }
+
+    internal constructor(mem: COpaquePointer) {
+        this.setRawMemory(mem)
+    }
+
+    //INTEROP
+    override fun getRawMemory(memScope: MemScope): COpaquePointer {
+        return _handle.getPointer(memScope)
+    }
+
+    override fun setRawMemory(mem: COpaquePointer) {
+        _handle = mem.reinterpret<godot_node_path>().pointed.readValue()
+    }
+
+
+    //API
+    fun getName(idx: Int): String {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_get_name)(it, idx)
+        }.toKString()
+    }
+
+    fun getNameCount(): Int {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_get_name_count)(it)
+        }
+    }
+
+    fun getProperty(): String {
+        return NodePath(
+            callNative {
+                checkNotNull(Godot.gdnative11.godot_node_path_get_as_property_path)(it)
+            }).toString()
+    }
+
+    fun getSubname(idx: Int): String {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
+        }
+    }
+
+    fun getSubnameCount(): Int {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_get_subname_count)(it)
+        }
+    }
+
+    fun isAbsolute(): Boolean {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_is_absolute)(it)
+        }
+    }
+
+    fun isEmpty(): Boolean {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_is_empty)(it)
+        }
+    }
+
+    fun getConcatenatedSubnames() {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
+        }
+    }
+
+
+    //UTILITIES
+    override fun equals(other: Any?): Boolean {
+        return if (other is NodePath) {
+            godot_node_path_operator_equal(_handle, other._handle)
+        } else {
+            false
+        }
+    }
+
+    override fun hashCode(): Int {
+        return _handle.hashCode()
+    }
+
+    override fun toString(): String {
+        return "NodePath($path)"
+    }
+
+    internal inline fun <T> callNative(block: MemScope.(CPointer<godot_node_path>) -> T): T {
+        return memScoped {
+            val ptr = _handle.ptr
+            val ret: T = block(ptr)
+            _handle = ptr.pointed.readValue()
+            ret
+        }
+    }
+}

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
@@ -1,0 +1,91 @@
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package godot.core
+
+import godot.gdnative.*
+import kotlinx.cinterop.*
+import godot.Object
+
+class RID : CoreType, Comparable<RID> {
+    //PROPERTIES
+    private lateinit var _handle: CValue<godot_rid>
+
+    val id: Int
+        get() = getID()
+
+    //CONSTRUCTOR
+    constructor() {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_rid_new)(it)
+        }
+    }
+
+
+    constructor(from: Object) {
+        callNative {
+            checkNotNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.getRawMemory(memScope))
+        }
+    }
+
+
+    internal constructor(native: CValue<godot_rid>) {
+        memScoped {
+            this@RID.setRawMemory(native.ptr)
+        }
+    }
+
+    internal constructor(mem: COpaquePointer) : this() {
+        this.setRawMemory(mem)
+    }
+
+    //INTEROP
+    override fun getRawMemory(memScope: MemScope): COpaquePointer {
+        return _handle.getPointer(memScope)
+    }
+
+    override fun setRawMemory(mem: COpaquePointer) {
+        _handle = mem.reinterpret<godot_rid>().pointed.readValue()
+    }
+
+
+    //API
+    fun getID(): Int {
+        return callNative {
+            checkNotNull(Godot.gdnative.godot_rid_get_id)(it)
+        }
+    }
+
+
+    //UTILITIES
+    override fun compareTo(other: RID): Int {
+        return when {
+            this == other -> 0
+            callNative { checkNotNull(Godot.gdnative.godot_rid_operator_less)(it, other._handle.ptr) } -> -1
+            else -> 1
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is RID -> callNative { checkNotNull(Godot.gdnative.godot_rid_operator_equal)(it, other._handle.ptr) }
+            else -> false
+        }
+    }
+
+    override fun hashCode(): Int {
+        return _handle.hashCode()
+    }
+
+    override fun toString(): String {
+        return "RID($id)"
+    }
+
+    internal inline fun <T> callNative(block: MemScope.(CPointer<godot_rid>) -> T): T {
+        return memScoped {
+            val ptr = _handle.ptr
+            val ret: T = block(ptr)
+            _handle = ptr.pointed.readValue()
+            ret
+        }
+    }
+}

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
@@ -4,7 +4,6 @@ package godot.core
 
 import godot.gdnative.*
 import kotlinx.cinterop.*
-import godot.Object
 
 class RID : CoreType, Comparable<RID> {
     //PROPERTIES
@@ -23,7 +22,7 @@ class RID : CoreType, Comparable<RID> {
 
     constructor(from: Object) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.getRawMemory(memScope))
+            checkNotNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
@@ -49,6 +49,9 @@ class RID : CoreType, Comparable<RID> {
 
 
     //API
+    /**
+     * Returns the ID of the referenced resource.
+     */
     fun getID(): Int {
         return callNative {
             checkNotNull(Godot.gdnative.godot_rid_get_id)(it)


### PR DESCRIPTION
Added NodePath
Added RID

Those coretypes directly use the Godot Gdnative API. It would be hard to reimplement them in kotlin because they need access to some internal Godot variables. 
Ex: Godot use a global counter to assign an ID to an RID. Gdnative doesn't give access to this counter.

RID doesn't compile for now as it needs the Object Class for its constructor and I don't have access to this one because the coretype directory doesn't depend on Gen in the gradle build.
We can either change the gradle file or recreate the GodotObject interface (root of all the gen classes) we previously had. 
What do you think ?