### PR TITLE
[Proposal] godot-extension-injection

### DIFF
--- a/godot-kotlin/godot-extension-injection/build.gradle.kts
+++ b/godot-kotlin/godot-extension-injection/build.gradle.kts
@@ -1,0 +1,65 @@
+import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
+import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+plugins {
+    kotlin("multiplatform")
+    `maven-publish`
+}
+
+kotlin {
+    // we don't have godot-library in the mobile targets yet, limit these to desktop for now
+    //has to be change in `GodotPlugin` of `godot-gradle-plugin` as well
+    macosX64("macos")
+    linuxX64("linux")
+    mingwX64("windows")
+
+    targets.withType<KotlinNativeTarget> {
+        compilations.getByName("main") {
+            defaultSourceSet {
+                kotlin.srcDir("src/native/kotlin")
+            }
+            dependencies {
+                implementation("com.utopia-rise:godot-library:${version}")
+            }
+        }
+    }
+    sourceSets {
+        all {
+            languageSettings.enableLanguageFeature("InlineClasses")
+        }
+    }
+}
+
+tasks {
+    build {
+        finalizedBy(publishToMavenLocal)
+    }
+
+    // workaround to upload gradle metadata file
+    // https://github.com/bintray/gradle-bintray-plugin/issues/229
+    withType<BintrayUploadTask> {
+        doFirst {
+            publishing.publications.withType<MavenPublication> {
+                buildDir.resolve("publications/$name/module.json").also {
+                    if (it.exists()) {
+                        artifact(object: FileBasedMavenArtifact(it) {
+                            override fun getDefaultExtension() = "module"
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
+//TODO: See how to do with mobile platforms
+project.extra["artifacts"] = when (currentOS) {
+    OS.LINUX -> arrayOf("kotlinMultiplatform", "metadata", "linux")
+    OS.WINDOWS -> arrayOf("windows")
+    OS.MACOS -> arrayOf("macos")
+}
+
+apply {
+    plugin(BintrayPublish::class.java)
+}

--- a/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/ClassBuilderExt.kt
+++ b/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/ClassBuilderExt.kt
@@ -1,0 +1,28 @@
+package godot.extension.injection
+
+import godot.Object
+import godot.core.ClassBuilder
+import godot.core.NodePath
+import godot.core.Variant
+import godot.gdnative.godot_property_hint
+import godot.registration.RPCMode
+import kotlinx.cinterop.StableRef
+import kotlin.reflect.KMutableProperty0
+
+fun <T: Object> ClassBuilder<T>.injectionHelper(
+    nodePathName: String,
+    propertyHelper: KMutableProperty0<NodePath>,
+    nodePath: String? = null
+) {
+    val injectionHelper = InjectionHelperPropertyHandler(propertyHelper)
+    classHandle.registerProperty(
+        nodePathName,
+        StableRef.create(injectionHelper).asCPointer(),
+        Variant.Type.NODE_PATH,
+        nodePath?.let { Variant(NodePath(it)) },
+        true,
+        RPCMode.DISABLED,
+        godot_property_hint.GODOT_PROPERTY_HINT_NONE,
+        "NodePath"
+    )
+}

--- a/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/InjectionHelperPropertyHandler.kt
+++ b/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/InjectionHelperPropertyHandler.kt
@@ -1,0 +1,17 @@
+package godot.extension.injection
+
+import godot.core.NodePath
+import godot.core.Variant
+import kotlin.reflect.KMutableProperty0
+
+class InjectionHelperPropertyHandler(private val nodePath: KMutableProperty0<NodePath>) {
+    fun get(): Variant {
+        return Variant.wrap(
+            nodePath.get()
+        )
+    }
+
+    fun set(value: Variant) {
+        nodePath.set(value.unwrap())
+    }
+}

--- a/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/NodeInjector.kt
+++ b/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/NodeInjector.kt
@@ -1,0 +1,7 @@
+package godot.extension.injection
+
+import godot.Node
+
+interface NodeInjector<T: Node> {
+    fun injectNodes(instance: T)
+}

--- a/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/annotations.kt
+++ b/godot-kotlin/godot-extension-injection/src/native/kotlin/godot/extension/injection/annotations.kt
@@ -1,0 +1,24 @@
+package godot.extension.injection
+
+/**
+ * Properties marked with this annotations will be populated when a corresponding `.inject` method is called
+ *
+ * Only useful in conjunction with either `JumpTableInjector` or `<YouClassName>Injector` injectors:
+ *
+ * ```
+ * override fun _ready() {
+ *     super._ready()
+ *     JumpTableInjector.injectNodes(this)
+ * }
+ * ```
+ * or:
+ * ```
+ * override fun _ready() {
+ *     super._ready()
+ *     SomeClassOfYoursInjector.injectNodes(this)
+ * }
+ * ```
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Inject(val exportedNodePathName: String = "", val nodePath: String = "")

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
@@ -6,8 +6,7 @@ import godot.internal.type.nullSafe
 import godot.registration.RPCMode
 import kotlinx.cinterop.*
 
-@PublishedApi
-internal class ClassHandle<T : Object>(
+class ClassHandle<T : Object>(
     private val nativescriptHandle: COpaquePointer,
     private val className: String,
     private val parentClassName: String,

--- a/samples/mini-games/build.gradle.kts
+++ b/samples/mini-games/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 plugins {
     //Change plugin version to last locally built, while there is no release.
     id("com.utopia-rise.godot-kotlin") version "0.1.0-3.2"
-    kotlin("multiplatform") version "1.3.71"
+    kotlin("multiplatform") version "1.3.72"
 }
 
 godot {
@@ -23,6 +23,11 @@ godot {
 
     configureTargets {
         compilations.getByName("main") {
+            defaultSourceSet {
+                dependencies {
+                    implementation("com.utopia-rise:godot-extension-injection:0.1.0-3.2")
+                }
+            }
             cinterops {
                 // create cinterop here
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "godot-kotlin"
 
 subdir("godot-kotlin") {
     include("godot-library")
+    include("godot-extension-injection")
 }
 
 subdir("plugins") {


### PR DESCRIPTION
When we started the merge we talked about possible extensions that a user can use together with this binding.

This is a proposal for such an extension. It is chosen over the coroutines as it covers much more than just code extension for the binding (which would be quite simple to implement).
It would cover:
- Code extensions for the user to use (Annotations, new code)
- Entry generation
- Annotation Processing

## Goal:
The user is able to directly inject nodes into properties without the need of `getNode(NodePath("some/node/Path"))`

This is achieved by introducing a new annotation: `@Inject`

- With it a user marks a property he wants to have injected.
- And calls the function `inject` inside the `_ready` function on a `Injector` class we generate
- We then generate a corresponding property of type `NodePath` and expose it to the editor.
- Inside the editor the user can drac and drop a node to the `NodePath` field in the inspector.
- When the game runs, Godot calls the setter of the `NodePath` property we exposed to the editor.
- With that `NodePath` we call `getNode` internally when the ready function is called

Upsides:
The user does not have to write all the time:
```kotlin
@RegisterProperty
lateinit var nodePath: NodePath
lateinit var node: Node
@RegisterProperty
lateinit var nodePath2: NodePath
lateinit var node2: Node
@RegisterProperty
lateinit var nodePath3: NodePath
lateinit var node3: Node

override fun _ready() {
    super._ready()
    node = getNode(nodePath)
    node2 = getNode(nodePath2)
    node3 = getNode(nodePath3)
}
```

he can just write:
```kotlin
@Inject
lateinit var node: Node
@Inject
lateinit var node2: Node
@Inject
lateinit var node3: Node

override fun _ready() {
    super._ready()
    JumpTableInjector.injectNodes(this) //injection happens here
}
```

For classes with many nodes that are injected with this approach. The first common way can introduce a lot of boilerplate code really fast

## How it should work
What will be generated is in the `TestingClass` for my convenience documented with comments in code

What is not yet present in this draft PR; the entry generation part
We would need to discuss how we want to implement the support for extensions for the `entry-generator` and the `annotation-processor`.
One way could be to load extension jars during entry generation runtime using reflection, but that's just an idea