### PR TITLE
Feature/check not null

### DIFF
--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
@@ -2,6 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.*
+import godot.internal.type.notNull
 import godot.registration.RPCMode
 import kotlinx.cinterop.*
 
@@ -39,7 +40,7 @@ internal class ClassHandle<T : Object>(
             } else {
                 Godot.nativescript.godot_nativescript_register_class
             }
-            checkNotNull(registerMethod)(
+            notNull(registerMethod)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 parentClassName.cstr.ptr,
@@ -61,7 +62,7 @@ internal class ClassHandle<T : Object>(
                 this.method = staticCFunction(::invokeMethod)
             }
 
-            checkNotNull(Godot.nativescript.godot_nativescript_register_method)(
+            notNull(Godot.nativescript.godot_nativescript_register_method)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 methodName.cstr.ptr,
@@ -92,15 +93,15 @@ internal class ClassHandle<T : Object>(
                     val argInfo = argInfos[index]
                     val value = parameters.getValue(key)
                     // argument name
-                    checkNotNull(Godot.gdnative.godot_string_parse_utf8)(argInfo.name.ptr, key.cstr.ptr)
+                    notNull(Godot.gdnative.godot_string_parse_utf8)(argInfo.name.ptr, key.cstr.ptr)
                     // argument type
                     argInfo.type = value.value.toInt()
                 }
                 args = argInfos.getPointer(this@memScoped)
-                checkNotNull(Godot.gdnative.godot_string_parse_utf8)(name.ptr, signalName.cstr.ptr)
+                notNull(Godot.gdnative.godot_string_parse_utf8)(name.ptr, signalName.cstr.ptr)
                 num_args = parameters.size
             }
-            checkNotNull(Godot.nativescript.godot_nativescript_register_signal)(
+            notNull(Godot.nativescript.godot_nativescript_register_signal)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 gdSignal.ptr
@@ -131,9 +132,9 @@ internal class ClassHandle<T : Object>(
                 usage = usageFlags
                 type = propertyType.value.toInt()
                 this.hint = hintType
-                checkNotNull(Godot.gdnative.godot_string_parse_utf8)(hint_string.ptr, hintString.cstr.ptr)
+                notNull(Godot.gdnative.godot_string_parse_utf8)(hint_string.ptr, hintString.cstr.ptr)
                 if (default != null) {
-                    checkNotNull(Godot.gdnative.godot_variant_new_copy)(default_value.ptr, default._handle.ptr)
+                    notNull(Godot.gdnative.godot_variant_new_copy)(default_value.ptr, default._handle.ptr)
                 }
             }
 
@@ -147,7 +148,7 @@ internal class ClassHandle<T : Object>(
                 set_func = staticCFunction(::setProperty)
             }
 
-            checkNotNull(Godot.nativescript.godot_nativescript_register_property)(
+            notNull(Godot.nativescript.godot_nativescript_register_property)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 propertyName.cstr.ptr,

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
@@ -2,7 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.*
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import godot.registration.RPCMode
 import kotlinx.cinterop.*
 
@@ -40,7 +40,7 @@ internal class ClassHandle<T : Object>(
             } else {
                 Godot.nativescript.godot_nativescript_register_class
             }
-            notNull(registerMethod)(
+            nullSafe(registerMethod)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 parentClassName.cstr.ptr,
@@ -62,7 +62,7 @@ internal class ClassHandle<T : Object>(
                 this.method = staticCFunction(::invokeMethod)
             }
 
-            notNull(Godot.nativescript.godot_nativescript_register_method)(
+            nullSafe(Godot.nativescript.godot_nativescript_register_method)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 methodName.cstr.ptr,
@@ -93,15 +93,15 @@ internal class ClassHandle<T : Object>(
                     val argInfo = argInfos[index]
                     val value = parameters.getValue(key)
                     // argument name
-                    notNull(Godot.gdnative.godot_string_parse_utf8)(argInfo.name.ptr, key.cstr.ptr)
+                    nullSafe(Godot.gdnative.godot_string_parse_utf8)(argInfo.name.ptr, key.cstr.ptr)
                     // argument type
                     argInfo.type = value.value.toInt()
                 }
                 args = argInfos.getPointer(this@memScoped)
-                notNull(Godot.gdnative.godot_string_parse_utf8)(name.ptr, signalName.cstr.ptr)
+                nullSafe(Godot.gdnative.godot_string_parse_utf8)(name.ptr, signalName.cstr.ptr)
                 num_args = parameters.size
             }
-            notNull(Godot.nativescript.godot_nativescript_register_signal)(
+            nullSafe(Godot.nativescript.godot_nativescript_register_signal)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 gdSignal.ptr
@@ -132,9 +132,9 @@ internal class ClassHandle<T : Object>(
                 usage = usageFlags
                 type = propertyType.value.toInt()
                 this.hint = hintType
-                notNull(Godot.gdnative.godot_string_parse_utf8)(hint_string.ptr, hintString.cstr.ptr)
+                nullSafe(Godot.gdnative.godot_string_parse_utf8)(hint_string.ptr, hintString.cstr.ptr)
                 if (default != null) {
-                    notNull(Godot.gdnative.godot_variant_new_copy)(default_value.ptr, default._handle.ptr)
+                    nullSafe(Godot.gdnative.godot_variant_new_copy)(default_value.ptr, default._handle.ptr)
                 }
             }
 
@@ -148,7 +148,7 @@ internal class ClassHandle<T : Object>(
                 set_func = staticCFunction(::setProperty)
             }
 
-            notNull(Godot.nativescript.godot_nativescript_register_property)(
+            nullSafe(Godot.nativescript.godot_nativescript_register_property)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 propertyName.cstr.ptr,

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
@@ -1,6 +1,7 @@
 package godot.core
 
 import godot.gdnative.*
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.AtomicReference
@@ -10,21 +11,21 @@ object Godot {
     private val nativescriptWrapper = AtomicReference<CPointer<godot_gdnative_ext_nativescript_api_struct>?>(null)
 
     internal val gdnative: godot_gdnative_core_api_struct
-        get() = checkNotNull(gdnativeWrapper.value).pointed
+        get() = notNull(gdnativeWrapper.value).pointed
 
     internal val gdnative11: godot_gdnative_core_1_1_api_struct
-        get() = checkNotNull(gdnative.next).reinterpret<godot_gdnative_core_1_1_api_struct>().pointed
+        get() = notNull(gdnative.next).reinterpret<godot_gdnative_core_1_1_api_struct>().pointed
 
     internal val gdnative12: godot_gdnative_core_1_2_api_struct
-        get() = checkNotNull(gdnative11.next).reinterpret<godot_gdnative_core_1_2_api_struct>().pointed
+        get() = notNull(gdnative11.next).reinterpret<godot_gdnative_core_1_2_api_struct>().pointed
 
     @PublishedApi
     internal val nativescript: godot_gdnative_ext_nativescript_api_struct
-        get() = checkNotNull(nativescriptWrapper.value).pointed
+        get() = notNull(nativescriptWrapper.value).pointed
 
     @PublishedApi
     internal val nativescript11: godot_gdnative_ext_nativescript_1_1_api_struct
-        get() = checkNotNull(nativescript.next).reinterpret<godot_gdnative_ext_nativescript_1_1_api_struct>().pointed
+        get() = notNull(nativescript.next).reinterpret<godot_gdnative_ext_nativescript_1_1_api_struct>().pointed
 
     internal val languageIndex: Int
         get() = languageIndexRef.value
@@ -34,12 +35,12 @@ object Godot {
     private val initHandle = AtomicInt(0)
 
     fun init(options: godot_gdnative_init_options) {
-        val gdnative = checkNotNull(options.api_struct)
+        val gdnative = notNull(options.api_struct)
         val extensionCount = gdnative.pointed.num_extensions.toInt()
-        val extensions = checkNotNull(gdnative.pointed.extensions)
+        val extensions = notNull(gdnative.pointed.extensions)
         lateinit var nativescript: CPointer<godot_gdnative_ext_nativescript_api_struct>
         (0 until extensionCount).forEach { i ->
-            val extension = checkNotNull(extensions[i])
+            val extension = notNull(extensions[i])
             val type = extension.pointed.type
             when (GDNATIVE_API_TYPES.byValue(type)) {
                 GDNATIVE_API_TYPES.GDNATIVE_EXT_NATIVESCRIPT -> {
@@ -60,7 +61,7 @@ object Godot {
                 alloc_instance_binding_data = staticCFunction(::createWrapper)
                 free_instance_binding_data = staticCFunction(::destroyWrapper)
             }
-            val index = checkNotNull(nativescript11.godot_nativescript_register_instance_binding_data_functions)(
+            val index = notNull(nativescript11.godot_nativescript_register_instance_binding_data_functions)(
                 info
             )
             languageIndexRef.compareAndSet(languageIndexRef.value, index)
@@ -68,7 +69,7 @@ object Godot {
     }
 
     fun nativescriptTerminate(handle: COpaquePointer) {
-        checkNotNull(nativescript11.godot_nativescript_unregister_instance_binding_data_functions)(languageIndex)
+        notNull(nativescript11.godot_nativescript_unregister_instance_binding_data_functions)(languageIndex)
     }
 
     fun terminate(options: godot_gdnative_terminate_options) {
@@ -87,19 +88,19 @@ object Godot {
 
     internal fun print(message: String) {
         memScoped {
-            checkNotNull(gdnative.godot_print)(message.toGDString().ptr)
+            notNull(gdnative.godot_print)(message.toGDString().ptr)
         }
     }
 
     internal fun printWarning(description: String, function: String, file: String, line: Int) {
         memScoped {
-            checkNotNull(gdnative.godot_print_warning)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
+            notNull(gdnative.godot_print_warning)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
         }
     }
 
     internal fun printError(description: String, function: String, file: String, line: Int) {
         memScoped {
-            checkNotNull(gdnative.godot_print_error)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
+            notNull(gdnative.godot_print_error)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
         }
     }
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
@@ -1,7 +1,7 @@
 package godot.core
 
 import godot.gdnative.*
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.AtomicReference
@@ -11,21 +11,21 @@ object Godot {
     private val nativescriptWrapper = AtomicReference<CPointer<godot_gdnative_ext_nativescript_api_struct>?>(null)
 
     internal val gdnative: godot_gdnative_core_api_struct
-        get() = notNull(gdnativeWrapper.value).pointed
+        get() = nullSafe(gdnativeWrapper.value).pointed
 
     internal val gdnative11: godot_gdnative_core_1_1_api_struct
-        get() = notNull(gdnative.next).reinterpret<godot_gdnative_core_1_1_api_struct>().pointed
+        get() = nullSafe(gdnative.next).reinterpret<godot_gdnative_core_1_1_api_struct>().pointed
 
     internal val gdnative12: godot_gdnative_core_1_2_api_struct
-        get() = notNull(gdnative11.next).reinterpret<godot_gdnative_core_1_2_api_struct>().pointed
+        get() = nullSafe(gdnative11.next).reinterpret<godot_gdnative_core_1_2_api_struct>().pointed
 
     @PublishedApi
     internal val nativescript: godot_gdnative_ext_nativescript_api_struct
-        get() = notNull(nativescriptWrapper.value).pointed
+        get() = nullSafe(nativescriptWrapper.value).pointed
 
     @PublishedApi
     internal val nativescript11: godot_gdnative_ext_nativescript_1_1_api_struct
-        get() = notNull(nativescript.next).reinterpret<godot_gdnative_ext_nativescript_1_1_api_struct>().pointed
+        get() = nullSafe(nativescript.next).reinterpret<godot_gdnative_ext_nativescript_1_1_api_struct>().pointed
 
     internal val languageIndex: Int
         get() = languageIndexRef.value
@@ -35,12 +35,12 @@ object Godot {
     private val initHandle = AtomicInt(0)
 
     fun init(options: godot_gdnative_init_options) {
-        val gdnative = notNull(options.api_struct)
+        val gdnative = nullSafe(options.api_struct)
         val extensionCount = gdnative.pointed.num_extensions.toInt()
-        val extensions = notNull(gdnative.pointed.extensions)
+        val extensions = nullSafe(gdnative.pointed.extensions)
         lateinit var nativescript: CPointer<godot_gdnative_ext_nativescript_api_struct>
         (0 until extensionCount).forEach { i ->
-            val extension = notNull(extensions[i])
+            val extension = nullSafe(extensions[i])
             val type = extension.pointed.type
             when (GDNATIVE_API_TYPES.byValue(type)) {
                 GDNATIVE_API_TYPES.GDNATIVE_EXT_NATIVESCRIPT -> {
@@ -61,7 +61,7 @@ object Godot {
                 alloc_instance_binding_data = staticCFunction(::createWrapper)
                 free_instance_binding_data = staticCFunction(::destroyWrapper)
             }
-            val index = notNull(nativescript11.godot_nativescript_register_instance_binding_data_functions)(
+            val index = nullSafe(nativescript11.godot_nativescript_register_instance_binding_data_functions)(
                 info
             )
             languageIndexRef.compareAndSet(languageIndexRef.value, index)
@@ -69,7 +69,7 @@ object Godot {
     }
 
     fun nativescriptTerminate(handle: COpaquePointer) {
-        notNull(nativescript11.godot_nativescript_unregister_instance_binding_data_functions)(languageIndex)
+        nullSafe(nativescript11.godot_nativescript_unregister_instance_binding_data_functions)(languageIndex)
     }
 
     fun terminate(options: godot_gdnative_terminate_options) {
@@ -88,19 +88,19 @@ object Godot {
 
     internal fun print(message: String) {
         memScoped {
-            notNull(gdnative.godot_print)(message.toGDString().ptr)
+            nullSafe(gdnative.godot_print)(message.toGDString().ptr)
         }
     }
 
     internal fun printWarning(description: String, function: String, file: String, line: Int) {
         memScoped {
-            notNull(gdnative.godot_print_warning)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
+            nullSafe(gdnative.godot_print_warning)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
         }
     }
 
     internal fun printError(description: String, function: String, file: String, line: Int) {
         memScoped {
-            notNull(gdnative.godot_print_error)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
+            nullSafe(gdnative.godot_print_error)(description.cstr.ptr, function.cstr.ptr, file.cstr.ptr, line)
         }
     }
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
@@ -1,7 +1,7 @@
 package godot.core
 
 import godot.Object
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.freeze
@@ -19,7 +19,7 @@ internal object TypeManager {
     fun registerUserType(nativescriptHandle: COpaquePointer, className: String, factory: () -> Object) {
         val ref = createAndRegisterTag(factory)
         memScoped {
-            notNull(Godot.nativescript11.godot_nativescript_set_type_tag)(
+            nullSafe(Godot.nativescript11.godot_nativescript_set_type_tag)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 ref
@@ -33,7 +33,7 @@ internal object TypeManager {
     fun registerEngineType(className: String, factory: () -> Object) {
         val ref = createAndRegisterTag(factory)
         memScoped {
-            notNull(Godot.nativescript11.godot_nativescript_set_global_type_tag)(
+            nullSafe(Godot.nativescript11.godot_nativescript_set_global_type_tag)(
                 Godot.languageIndex,
                 className.cstr.ptr,
                 ref
@@ -77,10 +77,10 @@ internal object TypeManager {
             val className = obj.getClass()
             // user defined type
             // this should be first otherwise casting to a user defined type won't work!
-            var tag = notNull(Godot.nativescript11.godot_nativescript_get_type_tag)(ptr)
+            var tag = nullSafe(Godot.nativescript11.godot_nativescript_get_type_tag)(ptr)
             // engine type
             if (tag == null) {
-                tag = notNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
+                tag = nullSafe(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
                     Godot.languageIndex,
                     className.cstr.ptr
                 )
@@ -90,7 +90,7 @@ internal object TypeManager {
             if (tag == null) {
                 var parentClass = ClassDB.getParentClass(className)
                 while (parentClass.isNotEmpty()) {
-                    tag = notNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
+                    tag = nullSafe(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
                         Godot.languageIndex,
                         parentClass.cstr.ptr
                     )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
@@ -1,6 +1,7 @@
 package godot.core
 
 import godot.Object
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.freeze
@@ -18,7 +19,7 @@ internal object TypeManager {
     fun registerUserType(nativescriptHandle: COpaquePointer, className: String, factory: () -> Object) {
         val ref = createAndRegisterTag(factory)
         memScoped {
-            checkNotNull(Godot.nativescript11.godot_nativescript_set_type_tag)(
+            notNull(Godot.nativescript11.godot_nativescript_set_type_tag)(
                 nativescriptHandle,
                 className.cstr.ptr,
                 ref
@@ -32,7 +33,7 @@ internal object TypeManager {
     fun registerEngineType(className: String, factory: () -> Object) {
         val ref = createAndRegisterTag(factory)
         memScoped {
-            checkNotNull(Godot.nativescript11.godot_nativescript_set_global_type_tag)(
+            notNull(Godot.nativescript11.godot_nativescript_set_global_type_tag)(
                 Godot.languageIndex,
                 className.cstr.ptr,
                 ref
@@ -76,10 +77,10 @@ internal object TypeManager {
             val className = obj.getClass()
             // user defined type
             // this should be first otherwise casting to a user defined type won't work!
-            var tag = checkNotNull(Godot.nativescript11.godot_nativescript_get_type_tag)(ptr)
+            var tag = notNull(Godot.nativescript11.godot_nativescript_get_type_tag)(ptr)
             // engine type
             if (tag == null) {
-                tag = checkNotNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
+                tag = notNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
                     Godot.languageIndex,
                     className.cstr.ptr
                 )
@@ -89,7 +90,7 @@ internal object TypeManager {
             if (tag == null) {
                 var parentClass = ClassDB.getParentClass(className)
                 while (parentClass.isNotEmpty()) {
-                    tag = checkNotNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
+                    tag = notNull(Godot.nativescript11.godot_nativescript_get_global_type_tag)(
                         Godot.languageIndex,
                         parentClass.cstr.ptr
                     )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Wrapper.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Wrapper.kt
@@ -1,5 +1,6 @@
 package godot.core
 
+import godot.internal.type.notNull
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.asStableRef
@@ -10,8 +11,8 @@ class Wrapped(val instance: COpaquePointer, val tag: COpaquePointer)
 
 fun createWrapper(data: COpaquePointer?, tag: COpaquePointer?, instance: COpaquePointer?): COpaquePointer? {
     val wrapped = Wrapped(
-        checkNotNull(instance),
-        checkNotNull(tag)
+        notNull(instance),
+        notNull(tag)
     )
     return StableRef.create(wrapped).asCPointer()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Wrapper.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Wrapper.kt
@@ -1,6 +1,6 @@
 package godot.core
 
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.asStableRef
@@ -11,8 +11,8 @@ class Wrapped(val instance: COpaquePointer, val tag: COpaquePointer)
 
 fun createWrapper(data: COpaquePointer?, tag: COpaquePointer?, instance: COpaquePointer?): COpaquePointer? {
     val wrapped = Wrapped(
-        notNull(instance),
-        notNull(tag)
+        nullSafe(instance),
+        nullSafe(tag)
     )
     return StableRef.create(wrapped).asCPointer()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/bridge.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/bridge.kt
@@ -2,26 +2,26 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_variant
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 fun createInstance(instance: COpaquePointer?, methodData: COpaquePointer?): COpaquePointer? {
-    val classHandle = notNull(methodData).asStableRef<ClassHandle<Object>>()
+    val classHandle = nullSafe(methodData).asStableRef<ClassHandle<Object>>()
         .get()
-    val kotlinInstance = classHandle.wrap(notNull(instance))
+    val kotlinInstance = classHandle.wrap(nullSafe(instance))
     kotlinInstance._onInit()
     val stableRef = StableRef.create(kotlinInstance)
     return stableRef.asCPointer()
 }
 
 fun disposeClassHandle(ref: COpaquePointer?) {
-    val handle = notNull(ref).asStableRef<ClassHandle<Object>>()
+    val handle = nullSafe(ref).asStableRef<ClassHandle<Object>>()
     handle.get().dispose()
     handle.dispose()
 }
 
 fun destroyInstance(instance: COpaquePointer?, methodData: COpaquePointer?, classData: COpaquePointer?) {
-    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = nullSafe(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
     kotlinInstance._onDestroy()
     kotlinInstanceRef.dispose()
@@ -34,9 +34,9 @@ fun invokeMethod(
     numArgs: Int,
     args: CPointer<CPointerVar<godot_variant>>?
 ): CValue<godot_variant> {
-    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = nullSafe(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val methodHandleRef = notNull(methodData).asStableRef<Function<Object, *>>()
+    val methodHandleRef = nullSafe(methodData).asStableRef<Function<Object, *>>()
     val methodHandle = methodHandleRef.get()
 
     check(methodHandle.parameterCount == numArgs) {
@@ -63,9 +63,9 @@ fun getProperty(
     methodData: COpaquePointer?,
     classData: COpaquePointer?
 ): CValue<godot_variant> {
-    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = nullSafe(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val propertyHandleRef = notNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
+    val propertyHandleRef = nullSafe(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
     val propertyHandler = propertyHandleRef.get()
 
     return propertyHandler.get(kotlinInstance)._handle
@@ -77,9 +77,9 @@ fun setProperty(
     classData: COpaquePointer?,
     value: CPointer<godot_variant>?
 ) {
-    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = nullSafe(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val propertyHandleRef = notNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
+    val propertyHandleRef = nullSafe(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
     val propertyHandler = propertyHandleRef.get()
     val arg = if (value == null) {
         Variant()

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/bridge.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/bridge.kt
@@ -2,25 +2,26 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_variant
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 fun createInstance(instance: COpaquePointer?, methodData: COpaquePointer?): COpaquePointer? {
-    val classHandle = checkNotNull(methodData).asStableRef<ClassHandle<Object>>()
+    val classHandle = notNull(methodData).asStableRef<ClassHandle<Object>>()
         .get()
-    val kotlinInstance = classHandle.wrap(checkNotNull(instance))
+    val kotlinInstance = classHandle.wrap(notNull(instance))
     kotlinInstance._onInit()
     val stableRef = StableRef.create(kotlinInstance)
     return stableRef.asCPointer()
 }
 
 fun disposeClassHandle(ref: COpaquePointer?) {
-    val handle = checkNotNull(ref).asStableRef<ClassHandle<Object>>()
+    val handle = notNull(ref).asStableRef<ClassHandle<Object>>()
     handle.get().dispose()
     handle.dispose()
 }
 
 fun destroyInstance(instance: COpaquePointer?, methodData: COpaquePointer?, classData: COpaquePointer?) {
-    val kotlinInstanceRef = checkNotNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
     kotlinInstance._onDestroy()
     kotlinInstanceRef.dispose()
@@ -33,9 +34,9 @@ fun invokeMethod(
     numArgs: Int,
     args: CPointer<CPointerVar<godot_variant>>?
 ): CValue<godot_variant> {
-    val kotlinInstanceRef = checkNotNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val methodHandleRef = checkNotNull(methodData).asStableRef<Function<Object, *>>()
+    val methodHandleRef = notNull(methodData).asStableRef<Function<Object, *>>()
     val methodHandle = methodHandleRef.get()
 
     check(methodHandle.parameterCount == numArgs) {
@@ -62,9 +63,9 @@ fun getProperty(
     methodData: COpaquePointer?,
     classData: COpaquePointer?
 ): CValue<godot_variant> {
-    val kotlinInstanceRef = checkNotNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val propertyHandleRef = checkNotNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
+    val propertyHandleRef = notNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
     val propertyHandler = propertyHandleRef.get()
 
     return propertyHandler.get(kotlinInstance)._handle
@@ -76,9 +77,9 @@ fun setProperty(
     classData: COpaquePointer?,
     value: CPointer<godot_variant>?
 ) {
-    val kotlinInstanceRef = checkNotNull(classData).asStableRef<Object>()
+    val kotlinInstanceRef = notNull(classData).asStableRef<Object>()
     val kotlinInstance = kotlinInstanceRef.get()
-    val propertyHandleRef = checkNotNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
+    val propertyHandleRef = notNull(methodData).asStableRef<MutablePropertyHandler<Object, *>>()
     val propertyHandler = propertyHandleRef.get()
     val arg = if (value == null) {
         Variant()

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Dictionary.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Dictionary.kt
@@ -22,7 +22,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_new)(it)
+            notNull(Godot.gdnative.godot_dictionary_new)(it)
         }
     }
 
@@ -52,7 +52,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun clear() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_clear)(it)
+            notNull(Godot.gdnative.godot_dictionary_clear)(it)
         }
     }
 
@@ -62,7 +62,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun duplicate(deep: Boolean = false) {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_dictionary_duplicate)(it, deep)
+            notNull(Godot.gdnative12.godot_dictionary_duplicate)(it, deep)
         }
     }
 
@@ -71,7 +71,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun empty(): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_empty)(it)
+            notNull(Godot.gdnative.godot_dictionary_empty)(it)
         }
     }
 
@@ -80,7 +80,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun erase(key: Variant) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_erase)(it, key._handle.ptr)
+            notNull(Godot.gdnative.godot_dictionary_erase)(it, key._handle.ptr)
         }
     }
     fun erase(key: Int) = erase(Variant(key))
@@ -97,7 +97,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun get(key: Variant, default: Variant = Variant()): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_dictionary_get_with_default)(
+                notNull(Godot.gdnative11.godot_dictionary_get_with_default)(
                     it,
                     key._handle.ptr,
                     default._handle.ptr
@@ -160,7 +160,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun has(key: Variant): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_has)(it, key._handle.ptr)
+            notNull(Godot.gdnative.godot_dictionary_has)(it, key._handle.ptr)
         }
     }
 
@@ -176,7 +176,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun hasAll(keys: VariantArray): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_has_all)(it, keys._handle.ptr)
+            notNull(Godot.gdnative.godot_dictionary_has_all)(it, keys._handle.ptr)
         }
     }
 
@@ -185,7 +185,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun hash(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_hash)(it)
+            notNull(Godot.gdnative.godot_dictionary_hash)(it)
         }
     }
 
@@ -195,7 +195,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun keys(): VariantArray {
         return VariantArray(
             callNative {
-                checkNotNull(Godot.gdnative.godot_dictionary_keys)(it)
+                notNull(Godot.gdnative.godot_dictionary_keys)(it)
             }
         )
     }
@@ -205,7 +205,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_size)(it)
+            notNull(Godot.gdnative.godot_dictionary_size)(it)
         }
     }
 
@@ -215,7 +215,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun values(): VariantArray {
         return VariantArray(
             callNative {
-                checkNotNull(Godot.gdnative.godot_dictionary_values)(it)
+                notNull(Godot.gdnative.godot_dictionary_values)(it)
             }
         )
     }
@@ -225,7 +225,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     operator fun get(key: Variant): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_dictionary_get)(it, key._handle.ptr)
+                notNull(Godot.gdnative.godot_dictionary_get)(it, key._handle.ptr)
             }
         )
     }
@@ -239,7 +239,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
 
     operator fun set(key: Variant, value: Variant) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_set)(it, key._handle.ptr, value._handle.ptr)
+            notNull(Godot.gdnative.godot_dictionary_set)(it, key._handle.ptr, value._handle.ptr)
         }
     }
 
@@ -306,7 +306,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
             return false
         }
         return callNative {
-            checkNotNull(Godot.gdnative.godot_dictionary_operator_equal)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_dictionary_operator_equal)(it, other._handle.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Dictionary.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Dictionary.kt
@@ -22,7 +22,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_dictionary_new)(it)
+            nullSafe(Godot.gdnative.godot_dictionary_new)(it)
         }
     }
 
@@ -52,7 +52,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun clear() {
         callNative {
-            notNull(Godot.gdnative.godot_dictionary_clear)(it)
+            nullSafe(Godot.gdnative.godot_dictionary_clear)(it)
         }
     }
 
@@ -62,7 +62,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun duplicate(deep: Boolean = false) {
         callNative {
-            notNull(Godot.gdnative12.godot_dictionary_duplicate)(it, deep)
+            nullSafe(Godot.gdnative12.godot_dictionary_duplicate)(it, deep)
         }
     }
 
@@ -71,7 +71,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun empty(): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_empty)(it)
+            nullSafe(Godot.gdnative.godot_dictionary_empty)(it)
         }
     }
 
@@ -80,7 +80,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun erase(key: Variant) {
         callNative {
-            notNull(Godot.gdnative.godot_dictionary_erase)(it, key._handle.ptr)
+            nullSafe(Godot.gdnative.godot_dictionary_erase)(it, key._handle.ptr)
         }
     }
     fun erase(key: Int) = erase(Variant(key))
@@ -97,7 +97,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun get(key: Variant, default: Variant = Variant()): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_dictionary_get_with_default)(
+                nullSafe(Godot.gdnative11.godot_dictionary_get_with_default)(
                     it,
                     key._handle.ptr,
                     default._handle.ptr
@@ -160,7 +160,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun has(key: Variant): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_has)(it, key._handle.ptr)
+            nullSafe(Godot.gdnative.godot_dictionary_has)(it, key._handle.ptr)
         }
     }
 
@@ -176,7 +176,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun hasAll(keys: VariantArray): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_has_all)(it, keys._handle.ptr)
+            nullSafe(Godot.gdnative.godot_dictionary_has_all)(it, keys._handle.ptr)
         }
     }
 
@@ -185,7 +185,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun hash(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_hash)(it)
+            nullSafe(Godot.gdnative.godot_dictionary_hash)(it)
         }
     }
 
@@ -195,7 +195,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun keys(): VariantArray {
         return VariantArray(
             callNative {
-                notNull(Godot.gdnative.godot_dictionary_keys)(it)
+                nullSafe(Godot.gdnative.godot_dictionary_keys)(it)
             }
         )
     }
@@ -205,7 +205,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_size)(it)
+            nullSafe(Godot.gdnative.godot_dictionary_size)(it)
         }
     }
 
@@ -215,7 +215,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     fun values(): VariantArray {
         return VariantArray(
             callNative {
-                notNull(Godot.gdnative.godot_dictionary_values)(it)
+                nullSafe(Godot.gdnative.godot_dictionary_values)(it)
             }
         )
     }
@@ -225,7 +225,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
     operator fun get(key: Variant): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_dictionary_get)(it, key._handle.ptr)
+                nullSafe(Godot.gdnative.godot_dictionary_get)(it, key._handle.ptr)
             }
         )
     }
@@ -239,7 +239,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
 
     operator fun set(key: Variant, value: Variant) {
         callNative {
-            notNull(Godot.gdnative.godot_dictionary_set)(it, key._handle.ptr, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_dictionary_set)(it, key._handle.ptr, value._handle.ptr)
         }
     }
 
@@ -306,7 +306,7 @@ class Dictionary : NativeCoreType<godot_dictionary_layout>, Iterable<Entry<Varia
             return false
         }
         return callNative {
-            notNull(Godot.gdnative.godot_dictionary_operator_equal)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_dictionary_operator_equal)(it, other._handle.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
@@ -26,7 +26,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun clear() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_clear)(it)
+            notNull(Godot.gdnative.godot_array_clear)(it)
         }
     }
 
@@ -35,7 +35,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun empty(): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_empty)(it)
+            notNull(Godot.gdnative.godot_array_empty)(it)
         }
     }
 
@@ -44,7 +44,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun hash(): NaturalT {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_hash)(it)
+            notNull(Godot.gdnative.godot_array_hash)(it)
         }.toNaturalT()
     }
 
@@ -53,7 +53,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun invert() {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_invert)(it)
+            notNull(Godot.gdnative.godot_array_invert)(it)
         }
     }
 
@@ -62,7 +62,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun remove(position: Int) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_remove)(it, position)
+            notNull(Godot.gdnative.godot_array_remove)(it, position)
         }
     }
 
@@ -72,7 +72,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun resize(size: Int) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_array_resize)(it, size)
         }
     }
 
@@ -83,7 +83,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun shuffle() {
         return callNative {
-            checkNotNull(Godot.gdnative11.godot_array_shuffle)(it)
+            notNull(Godot.gdnative11.godot_array_shuffle)(it)
         }
     }
 
@@ -92,7 +92,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_size)(it)
+            notNull(Godot.gdnative.godot_array_size)(it)
         }
     }
 
@@ -101,7 +101,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun sort() {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_sort)(it)
+            notNull(Godot.gdnative.godot_array_sort)(it)
         }
     }
 
@@ -111,7 +111,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun sortCustom(obj: Object, func: String) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().ptr)
+            notNull(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
@@ -26,7 +26,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun clear() {
         callNative {
-            notNull(Godot.gdnative.godot_array_clear)(it)
+            nullSafe(Godot.gdnative.godot_array_clear)(it)
         }
     }
 
@@ -35,7 +35,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun empty(): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_empty)(it)
+            nullSafe(Godot.gdnative.godot_array_empty)(it)
         }
     }
 
@@ -44,7 +44,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun hash(): NaturalT {
         return callNative {
-            notNull(Godot.gdnative.godot_array_hash)(it)
+            nullSafe(Godot.gdnative.godot_array_hash)(it)
         }.toNaturalT()
     }
 
@@ -53,7 +53,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun invert() {
         return callNative {
-            notNull(Godot.gdnative.godot_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_array_invert)(it)
         }
     }
 
@@ -62,7 +62,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun remove(position: Int) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_remove)(it, position)
+            nullSafe(Godot.gdnative.godot_array_remove)(it, position)
         }
     }
 
@@ -72,7 +72,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun resize(size: Int) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_array_resize)(it, size)
         }
     }
 
@@ -83,7 +83,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun shuffle() {
         return callNative {
-            notNull(Godot.gdnative11.godot_array_shuffle)(it)
+            nullSafe(Godot.gdnative11.godot_array_shuffle)(it)
         }
     }
 
@@ -92,7 +92,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_size)(it)
+            nullSafe(Godot.gdnative.godot_array_size)(it)
         }
     }
 
@@ -101,7 +101,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun sort() {
         return callNative {
-            notNull(Godot.gdnative.godot_array_sort)(it)
+            nullSafe(Godot.gdnative.godot_array_sort)(it)
         }
     }
 
@@ -111,7 +111,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun sortCustom(obj: Object, func: String) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
@@ -14,7 +14,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     val path: String
         get() {
             return callNative {
-                checkNotNull(Godot.gdnative.godot_node_path_as_string)(it)
+                notNull(Godot.gdnative.godot_node_path_as_string)(it)
             }.toKString()
         }
 
@@ -22,29 +22,29 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
+            notNull(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
         }
     }
 
     constructor(from: String) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_new)(it, from.toGDString().ptr)
+            notNull(Godot.gdnative.godot_node_path_new)(it, from.toGDString().ptr)
         }
     }
 
     constructor(from: NodePath) {
         _handle = cValue{}
         callNative {
-            val str =  checkNotNull(Godot.gdnative.godot_node_path_as_string)(from._handle.ptr)
-            checkNotNull(Godot.gdnative.godot_node_path_new)(it, str.ptr)
+            val str =  notNull(Godot.gdnative.godot_node_path_as_string)(from._handle.ptr)
+            notNull(Godot.gdnative.godot_node_path_new)(it, str.ptr)
         }
     }
 
 
     internal constructor(native: CValue<godot_node_path_layout>) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_new_copy)(it, native.ptr)
+            notNull(Godot.gdnative.godot_node_path_new_copy)(it, native.ptr)
         }
     }
 
@@ -68,7 +68,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getName(idx: Int): String {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_get_name)(it, idx)
+            notNull(Godot.gdnative.godot_node_path_get_name)(it, idx)
         }.toKString()
 
     }
@@ -78,7 +78,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getNameCount(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_get_name_count)(it)
+            notNull(Godot.gdnative.godot_node_path_get_name_count)(it)
         }
     }
 
@@ -88,7 +88,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     fun getProperty(): String {
         return NodePath(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_node_path_get_as_property_path)(it)
+                notNull(Godot.gdnative11.godot_node_path_get_as_property_path)(it)
             }).toString()
     }
 
@@ -97,7 +97,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getSubname(idx: Int): String {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
+            notNull(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
         }
     }
 
@@ -106,7 +106,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getSubnameCount(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_get_subname_count)(it)
+            notNull(Godot.gdnative.godot_node_path_get_subname_count)(it)
         }
     }
 
@@ -115,7 +115,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun isAbsolute(): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_is_absolute)(it)
+            notNull(Godot.gdnative.godot_node_path_is_absolute)(it)
         }
     }
 
@@ -124,7 +124,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun isEmpty(): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_is_empty)(it)
+            notNull(Godot.gdnative.godot_node_path_is_empty)(it)
         }
     }
 
@@ -133,7 +133,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getConcatenatedSubnames(): String {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
+            notNull(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
         }
     }
 
@@ -144,7 +144,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     override fun equals(other: Any?): Boolean {
         return if (other is NodePath) {
             callNative{
-                checkNotNull(Godot.gdnative.godot_node_path_operator_equal)(it, other._handle.ptr)
+                notNull(Godot.gdnative.godot_node_path_operator_equal)(it, other._handle.ptr)
             }
         } else {
             false

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
@@ -2,9 +2,7 @@
 
 package godot.core
 
-import godot.gdnative.godot_node_path
 import godot.gdnative.godot_node_path_layout
-import godot.gdnative.godot_node_path_operator_equal
 import godot.internal.type.*
 import kotlinx.cinterop.*
 
@@ -14,7 +12,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     val path: String
         get() {
             return callNative {
-                notNull(Godot.gdnative.godot_node_path_as_string)(it)
+                nullSafe(Godot.gdnative.godot_node_path_as_string)(it)
             }.toKString()
         }
 
@@ -22,29 +20,29 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
         }
     }
 
     constructor(from: String) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_node_path_new)(it, from.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new)(it, from.toGDString().ptr)
         }
     }
 
     constructor(from: NodePath) {
         _handle = cValue{}
         callNative {
-            val str =  notNull(Godot.gdnative.godot_node_path_as_string)(from._handle.ptr)
-            notNull(Godot.gdnative.godot_node_path_new)(it, str.ptr)
+            val str =  nullSafe(Godot.gdnative.godot_node_path_as_string)(from._handle.ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new)(it, str.ptr)
         }
     }
 
 
     internal constructor(native: CValue<godot_node_path_layout>) {
         callNative {
-            notNull(Godot.gdnative.godot_node_path_new_copy)(it, native.ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new_copy)(it, native.ptr)
         }
     }
 
@@ -68,7 +66,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getName(idx: Int): String {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_get_name)(it, idx)
+            nullSafe(Godot.gdnative.godot_node_path_get_name)(it, idx)
         }.toKString()
 
     }
@@ -78,7 +76,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getNameCount(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_get_name_count)(it)
+            nullSafe(Godot.gdnative.godot_node_path_get_name_count)(it)
         }
     }
 
@@ -88,7 +86,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     fun getProperty(): String {
         return NodePath(
             callNative {
-                notNull(Godot.gdnative11.godot_node_path_get_as_property_path)(it)
+                nullSafe(Godot.gdnative11.godot_node_path_get_as_property_path)(it)
             }).toString()
     }
 
@@ -97,7 +95,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getSubname(idx: Int): String {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
+            nullSafe(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
         }
     }
 
@@ -106,7 +104,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getSubnameCount(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_get_subname_count)(it)
+            nullSafe(Godot.gdnative.godot_node_path_get_subname_count)(it)
         }
     }
 
@@ -115,7 +113,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun isAbsolute(): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_is_absolute)(it)
+            nullSafe(Godot.gdnative.godot_node_path_is_absolute)(it)
         }
     }
 
@@ -124,7 +122,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun isEmpty(): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_is_empty)(it)
+            nullSafe(Godot.gdnative.godot_node_path_is_empty)(it)
         }
     }
 
@@ -133,7 +131,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getConcatenatedSubnames(): String {
         return callNative {
-            notNull(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
+            nullSafe(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
         }
     }
 
@@ -144,7 +142,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     override fun equals(other: Any?): Boolean {
         return if (other is NodePath) {
             callNative{
-                notNull(Godot.gdnative.godot_node_path_operator_equal)(it, other._handle.ptr)
+                nullSafe(Godot.gdnative.godot_node_path_operator_equal)(it, other._handle.ptr)
             }
         } else {
             false

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
@@ -3,7 +3,6 @@
 package godot.core
 
 import godot.Object
-import godot.gdnative.godot_rid
 import godot.gdnative.godot_rid_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,7 +16,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_rid_new)(it)
+            nullSafe(Godot.gdnative.godot_rid_new)(it)
         }
     }
 
@@ -25,7 +24,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     constructor(from: Object) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.ptr)
+            nullSafe(Godot.gdnative.godot_rid_new_with_resource)(it, from.ptr)
         }
     }
 
@@ -56,7 +55,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
      */
     fun getID(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_rid_get_id)(it)
+            nullSafe(Godot.gdnative.godot_rid_get_id)(it)
         }
     }
 
@@ -67,14 +66,14 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     override fun compareTo(other: RID): Int {
         return when {
             this == other -> 0
-            callNative { notNull(Godot.gdnative.godot_rid_operator_less)(it, other._handle.ptr) } -> -1
+            callNative { nullSafe(Godot.gdnative.godot_rid_operator_less)(it, other._handle.ptr) } -> -1
             else -> 1
         }
     }
 
     override fun equals(other: Any?): Boolean {
         return when (other) {
-            is RID -> callNative { notNull(Godot.gdnative.godot_rid_operator_equal)(it, other._handle.ptr) }
+            is RID -> callNative { nullSafe(Godot.gdnative.godot_rid_operator_equal)(it, other._handle.ptr) }
             else -> false
         }
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/RID.kt
@@ -17,7 +17,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_rid_new)(it)
+            notNull(Godot.gdnative.godot_rid_new)(it)
         }
     }
 
@@ -25,7 +25,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     constructor(from: Object) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.ptr)
+            notNull(Godot.gdnative.godot_rid_new_with_resource)(it, from.ptr)
         }
     }
 
@@ -56,7 +56,7 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
      */
     fun getID(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_rid_get_id)(it)
+            notNull(Godot.gdnative.godot_rid_get_id)(it)
         }
     }
 
@@ -67,14 +67,14 @@ class RID : NativeCoreType<godot_rid_layout>, Comparable<RID> {
     override fun compareTo(other: RID): Int {
         return when {
             this == other -> 0
-            callNative { checkNotNull(Godot.gdnative.godot_rid_operator_less)(it, other._handle.ptr) } -> -1
+            callNative { notNull(Godot.gdnative.godot_rid_operator_less)(it, other._handle.ptr) } -> -1
             else -> 1
         }
     }
 
     override fun equals(other: Any?): Boolean {
         return when (other) {
-            is RID -> callNative { checkNotNull(Godot.gdnative.godot_rid_operator_equal)(it, other._handle.ptr) }
+            is RID -> callNative { notNull(Godot.gdnative.godot_rid_operator_equal)(it, other._handle.ptr) }
             else -> false
         }
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
@@ -2,9 +2,8 @@
 
 package godot.core
 
-import godot.gdnative.godot_string
 import godot.gdnative.godot_string_layout
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 
@@ -15,10 +14,10 @@ internal fun String(ptr: COpaquePointer): String {
 
 internal fun CValue<godot_string_layout>.toKString(): String {
     return memScoped {
-        val charString = notNull(Godot.gdnative.godot_string_utf8)(this@toKString.ptr)
-        val ret = notNull(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
+        val charString = nullSafe(Godot.gdnative.godot_string_utf8)(this@toKString.ptr)
+        val ret = nullSafe(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
             ?: throw NullPointerException("Failed to convert Godot-string to Kotlin-string")
-        notNull(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
+        nullSafe(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
         ret
     }
 }
@@ -31,8 +30,8 @@ internal fun String.getRawMemory(memScope: MemScope): COpaquePointer {
 internal fun String.toGDString(): CValue<godot_string_layout> {
     return memScoped {
         cValue {
-            notNull(Godot.gdnative.godot_string_new)(this.ptr)
-            notNull(Godot.gdnative.godot_string_parse_utf8)(
+            nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
+            nullSafe(Godot.gdnative.godot_string_parse_utf8)(
                 this.ptr,
                 this@toGDString.cstr.ptr
             )
@@ -43,14 +42,14 @@ internal fun String.toGDString(): CValue<godot_string_layout> {
 internal fun <T> String.asGDString(block: MemScope.(CValue<godot_string_layout>) -> T): T {
     return memScoped {
         val gdString = cValue<godot_string_layout> {
-            notNull(Godot.gdnative.godot_string_new)(this.ptr)
-            notNull(Godot.gdnative.godot_string_parse_utf8)(
+            nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
+            nullSafe(Godot.gdnative.godot_string_parse_utf8)(
                 this.ptr,
                 this@asGDString.cstr.ptr
             )
         }
         val ret: T = block(this, gdString)
-        notNull(Godot.gdnative.godot_string_destroy)(gdString.ptr)
+        nullSafe(Godot.gdnative.godot_string_destroy)(gdString.ptr)
         ret
     }
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
@@ -4,6 +4,7 @@ package godot.core
 
 import godot.gdnative.godot_string
 import godot.gdnative.godot_string_layout
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 
@@ -14,10 +15,10 @@ internal fun String(ptr: COpaquePointer): String {
 
 internal fun CValue<godot_string_layout>.toKString(): String {
     return memScoped {
-        val charString = checkNotNull(Godot.gdnative.godot_string_utf8)(this@toKString.ptr)
-        val ret = checkNotNull(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
+        val charString = notNull(Godot.gdnative.godot_string_utf8)(this@toKString.ptr)
+        val ret = notNull(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
             ?: throw NullPointerException("Failed to convert Godot-string to Kotlin-string")
-        checkNotNull(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
+        notNull(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
         ret
     }
 }
@@ -30,8 +31,8 @@ internal fun String.getRawMemory(memScope: MemScope): COpaquePointer {
 internal fun String.toGDString(): CValue<godot_string_layout> {
     return memScoped {
         cValue {
-            checkNotNull(Godot.gdnative.godot_string_new)(this.ptr)
-            checkNotNull(Godot.gdnative.godot_string_parse_utf8)(
+            notNull(Godot.gdnative.godot_string_new)(this.ptr)
+            notNull(Godot.gdnative.godot_string_parse_utf8)(
                 this.ptr,
                 this@toGDString.cstr.ptr
             )
@@ -42,14 +43,14 @@ internal fun String.toGDString(): CValue<godot_string_layout> {
 internal fun <T> String.asGDString(block: MemScope.(CValue<godot_string_layout>) -> T): T {
     return memScoped {
         val gdString = cValue<godot_string_layout> {
-            checkNotNull(Godot.gdnative.godot_string_new)(this.ptr)
-            checkNotNull(Godot.gdnative.godot_string_parse_utf8)(
+            notNull(Godot.gdnative.godot_string_new)(this.ptr)
+            notNull(Godot.gdnative.godot_string_parse_utf8)(
                 this.ptr,
                 this@asGDString.cstr.ptr
             )
         }
         val ret: T = block(this, gdString)
-        checkNotNull(Godot.gdnative.godot_string_destroy)(gdString.ptr)
+        notNull(Godot.gdnative.godot_string_destroy)(gdString.ptr)
         ret
     }
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
@@ -14,7 +14,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
     val type: Type
         get() {
             return memScoped {
-                Type.from(notNull(Godot.gdnative.godot_variant_get_type)(_handle.ptr).value.toNaturalT())
+                Type.from(nullSafe(Godot.gdnative.godot_variant_get_type)(_handle.ptr).value.toNaturalT())
             }
         }
 
@@ -262,7 +262,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBoolean(): Boolean {
         return memScoped {
-            notNull(Godot.gdnative.godot_variant_as_bool)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_bool)(_handle.ptr)
         }
     }
 
@@ -278,7 +278,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asLong(): Long {
         return memScoped {
-            notNull(Godot.gdnative.godot_variant_as_int)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_int)(_handle.ptr)
         }
     }
 
@@ -294,7 +294,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asDouble(): Double {
         return memScoped {
-            notNull(Godot.gdnative.godot_variant_as_real)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_real)(_handle.ptr)
         }
     }
 
@@ -314,7 +314,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asString(): String {
         val gdString = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_string)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_string)(_handle.ptr)
         }
         return gdString.toKString()
     }
@@ -324,7 +324,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector2(): Vector2 {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_vector2)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_vector2)(_handle.ptr)
         }
         return Vector2(value)
     }
@@ -334,7 +334,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRect2(): Rect2 {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_rect2)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_rect2)(_handle.ptr)
         }
         return Rect2(value)
     }
@@ -344,7 +344,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector3(): Vector3 {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_vector3)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_vector3)(_handle.ptr)
         }
         return Vector3(value)
     }
@@ -354,7 +354,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform2D(): Transform2D {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_transform2d)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_transform2d)(_handle.ptr)
         }
         return Transform2D(value)
     }
@@ -364,7 +364,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPlane(): Plane {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_plane)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_plane)(_handle.ptr)
         }
         return Plane(value)
     }
@@ -374,7 +374,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asQuat(): Quat {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_quat)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_quat)(_handle.ptr)
         }
         return Quat(value)
     }
@@ -384,7 +384,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asAABB(): AABB {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_aabb)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_aabb)(_handle.ptr)
         }
         return AABB(value)
     }
@@ -394,7 +394,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBasis(): Basis {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_basis)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_basis)(_handle.ptr)
         }
         return Basis(value)
     }
@@ -404,7 +404,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform(): Transform {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_transform)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_transform)(_handle.ptr)
         }
         return Transform(value)
     }
@@ -414,7 +414,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asColor(): Color {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_color)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_color)(_handle.ptr)
         }
         return Color(value)
     }
@@ -424,7 +424,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asNodePath(): NodePath {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_node_path)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_node_path)(_handle.ptr)
         }
         return NodePath(value)
     }
@@ -434,7 +434,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRID(): RID {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_rid)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_rid)(_handle.ptr)
         }
         return RID(value)
     }
@@ -445,7 +445,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asObject(): Object? {
         return memScoped {
-            val ptr = notNull(Godot.gdnative.godot_variant_as_object)(_handle.ptr)
+            val ptr = nullSafe(Godot.gdnative.godot_variant_as_object)(_handle.ptr)
             if (ptr == null) {
                 null
             } else {
@@ -459,7 +459,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asDictionary(): Dictionary {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_dictionary)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_dictionary)(_handle.ptr)
         }
         return Dictionary(value)
     }
@@ -469,7 +469,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVariantArray(): VariantArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return VariantArray(value)
     }
@@ -479,7 +479,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asAABBArray(): AABBArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return AABBArray(value)
     }
@@ -489,7 +489,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBasisArray(): BasisArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return BasisArray(value)
     }
@@ -499,7 +499,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asColorArray(): ColorArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return ColorArray(value)
     }
@@ -509,7 +509,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asNodePathArray(): NodePathArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return NodePathArray(value)
     }
@@ -519,7 +519,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPlaneArray(): PlaneArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return PlaneArray(value)
     }
@@ -529,7 +529,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asQuatArray(): QuatArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return QuatArray(value)
     }
@@ -539,7 +539,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRect2Array(): Rect2Array {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Rect2Array(value)
     }
@@ -549,7 +549,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRIDArray(): RIDArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return RIDArray(value)
     }
@@ -559,7 +559,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform2DArray(): Transform2DArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Transform2DArray(value)
     }
@@ -569,7 +569,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransformArray(): TransformArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return TransformArray(value)
     }
@@ -579,7 +579,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector2Array(): Vector2Array {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Vector2Array(value)
     }
@@ -589,7 +589,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector3Array(): Vector3Array {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Vector3Array(value)
     }
@@ -599,7 +599,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBoolVariantArray(): BoolVariantArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return BoolVariantArray(value)
     }
@@ -609,7 +609,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asIntVariantArray(): IntVariantArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return IntVariantArray(value)
     }
@@ -619,7 +619,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRealVariantArray(): RealVariantArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return RealVariantArray(value)
     }
@@ -629,7 +629,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asStringVariantArray(): StringVariantArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return StringVariantArray(value)
     }
@@ -639,7 +639,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolByteArray(): PoolByteArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_byte_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_byte_array)(_handle.ptr)
         }
         return PoolByteArray(value)
     }
@@ -649,7 +649,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolColorArray(): PoolColorArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_color_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_color_array)(_handle.ptr)
         }
         return PoolColorArray(value)
     }
@@ -659,7 +659,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolIntArray(): PoolIntArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_int_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_int_array)(_handle.ptr)
         }
         return PoolIntArray(value)
     }
@@ -669,7 +669,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolRealArray(): PoolRealArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_real_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_real_array)(_handle.ptr)
         }
         return PoolRealArray(value)
     }
@@ -679,7 +679,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolStringArray(): PoolStringArray {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_string_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_string_array)(_handle.ptr)
         }
         return PoolStringArray(value)
     }
@@ -689,7 +689,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolVector2Array(): PoolVector2Array {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_vector2_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_vector2_array)(_handle.ptr)
         }
         return PoolVector2Array(value)
     }
@@ -699,7 +699,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolVector3Array(): PoolVector3Array {
         val value = memScoped {
-            notNull(Godot.gdnative.godot_variant_as_pool_vector3_array)(_handle.ptr)
+            nullSafe(Godot.gdnative.godot_variant_as_pool_vector3_array)(_handle.ptr)
         }
         return PoolVector3Array(value)
     }
@@ -745,7 +745,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
 fun Variant() = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_nil)(this.ptr)
+            nullSafe(Godot.gdnative.godot_variant_new_nil)(this.ptr)
         }
     }
 )
@@ -754,7 +754,7 @@ fun Variant() = Variant(
 fun Variant(from: Boolean) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_bool)(this.ptr, from)
+            nullSafe(Godot.gdnative.godot_variant_new_bool)(this.ptr, from)
         }
     }
 )
@@ -762,7 +762,7 @@ fun Variant(from: Boolean) = Variant(
 fun Variant(from: Int) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.toLong())
+            nullSafe(Godot.gdnative.godot_variant_new_int)(this.ptr, from.toLong())
         }
     }
 )
@@ -770,7 +770,7 @@ fun Variant(from: Int) = Variant(
 fun <T : Enum<T>> Variant(from: Enum<T>) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.ordinal.toLong())
+            nullSafe(Godot.gdnative.godot_variant_new_int)(this.ptr, from.ordinal.toLong())
         }
     }
 )
@@ -778,7 +778,7 @@ fun <T : Enum<T>> Variant(from: Enum<T>) = Variant(
 fun Variant(from: Long) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from)
+            nullSafe(Godot.gdnative.godot_variant_new_int)(this.ptr, from)
         }
     }
 )
@@ -786,7 +786,7 @@ fun Variant(from: Long) = Variant(
 fun Variant(from: Float) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from.toDouble())
+            nullSafe(Godot.gdnative.godot_variant_new_real)(this.ptr, from.toDouble())
         }
     }
 )
@@ -794,7 +794,7 @@ fun Variant(from: Float) = Variant(
 fun Variant(from: Double) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from)
+            nullSafe(Godot.gdnative.godot_variant_new_real)(this.ptr, from)
         }
     }
 )
@@ -802,7 +802,7 @@ fun Variant(from: Double) = Variant(
 fun Variant(from: String) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().ptr)
         }
     }
 )
@@ -812,7 +812,7 @@ fun Variant(from: String) = Variant(
 fun Variant(from: Object) = Variant(
     memScoped {
         cValue<godot_variant> {
-            notNull(Godot.gdnative.godot_variant_new_object)(this.ptr, from.ptr)
+            nullSafe(Godot.gdnative.godot_variant_new_object)(this.ptr, from.ptr)
         }
     }
 )
@@ -828,7 +828,7 @@ internal fun <T : CPointed> wrapCore(
         memScoped {
             val ptr = core.getRawMemory(this).reinterpret<T>()
             cValue<godot_variant> {
-                notNull(block)(this.ptr, ptr)
+                nullSafe(block)(this.ptr, ptr)
             }
         }
     )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
@@ -14,7 +14,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
     val type: Type
         get() {
             return memScoped {
-                Type.from(checkNotNull(Godot.gdnative.godot_variant_get_type)(_handle.ptr).value.toNaturalT())
+                Type.from(notNull(Godot.gdnative.godot_variant_get_type)(_handle.ptr).value.toNaturalT())
             }
         }
 
@@ -262,7 +262,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBoolean(): Boolean {
         return memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_bool)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_bool)(_handle.ptr)
         }
     }
 
@@ -278,7 +278,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asLong(): Long {
         return memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_int)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_int)(_handle.ptr)
         }
     }
 
@@ -294,7 +294,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asDouble(): Double {
         return memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_real)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_real)(_handle.ptr)
         }
     }
 
@@ -314,7 +314,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asString(): String {
         val gdString = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_string)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_string)(_handle.ptr)
         }
         return gdString.toKString()
     }
@@ -324,7 +324,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector2(): Vector2 {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_vector2)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_vector2)(_handle.ptr)
         }
         return Vector2(value)
     }
@@ -334,7 +334,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRect2(): Rect2 {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_rect2)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_rect2)(_handle.ptr)
         }
         return Rect2(value)
     }
@@ -344,7 +344,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector3(): Vector3 {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_vector3)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_vector3)(_handle.ptr)
         }
         return Vector3(value)
     }
@@ -354,7 +354,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform2D(): Transform2D {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_transform2d)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_transform2d)(_handle.ptr)
         }
         return Transform2D(value)
     }
@@ -364,7 +364,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPlane(): Plane {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_plane)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_plane)(_handle.ptr)
         }
         return Plane(value)
     }
@@ -374,7 +374,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asQuat(): Quat {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_quat)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_quat)(_handle.ptr)
         }
         return Quat(value)
     }
@@ -384,7 +384,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asAABB(): AABB {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_aabb)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_aabb)(_handle.ptr)
         }
         return AABB(value)
     }
@@ -394,7 +394,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBasis(): Basis {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_basis)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_basis)(_handle.ptr)
         }
         return Basis(value)
     }
@@ -404,7 +404,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform(): Transform {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_transform)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_transform)(_handle.ptr)
         }
         return Transform(value)
     }
@@ -414,7 +414,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asColor(): Color {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_color)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_color)(_handle.ptr)
         }
         return Color(value)
     }
@@ -424,7 +424,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asNodePath(): NodePath {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_node_path)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_node_path)(_handle.ptr)
         }
         return NodePath(value)
     }
@@ -434,7 +434,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRID(): RID {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_rid)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_rid)(_handle.ptr)
         }
         return RID(value)
     }
@@ -445,7 +445,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asObject(): Object? {
         return memScoped {
-            val ptr = checkNotNull(Godot.gdnative.godot_variant_as_object)(_handle.ptr)
+            val ptr = notNull(Godot.gdnative.godot_variant_as_object)(_handle.ptr)
             if (ptr == null) {
                 null
             } else {
@@ -459,7 +459,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asDictionary(): Dictionary {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_dictionary)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_dictionary)(_handle.ptr)
         }
         return Dictionary(value)
     }
@@ -469,7 +469,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVariantArray(): VariantArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return VariantArray(value)
     }
@@ -479,7 +479,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asAABBArray(): AABBArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return AABBArray(value)
     }
@@ -489,7 +489,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBasisArray(): BasisArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return BasisArray(value)
     }
@@ -499,7 +499,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asColorArray(): ColorArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return ColorArray(value)
     }
@@ -509,7 +509,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asNodePathArray(): NodePathArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return NodePathArray(value)
     }
@@ -519,7 +519,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPlaneArray(): PlaneArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return PlaneArray(value)
     }
@@ -529,7 +529,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asQuatArray(): QuatArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return QuatArray(value)
     }
@@ -539,7 +539,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRect2Array(): Rect2Array {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Rect2Array(value)
     }
@@ -549,7 +549,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRIDArray(): RIDArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return RIDArray(value)
     }
@@ -559,7 +559,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransform2DArray(): Transform2DArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Transform2DArray(value)
     }
@@ -569,7 +569,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asTransformArray(): TransformArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return TransformArray(value)
     }
@@ -579,7 +579,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector2Array(): Vector2Array {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Vector2Array(value)
     }
@@ -589,7 +589,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asVector3Array(): Vector3Array {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return Vector3Array(value)
     }
@@ -599,7 +599,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asBoolVariantArray(): BoolVariantArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return BoolVariantArray(value)
     }
@@ -609,7 +609,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asIntVariantArray(): IntVariantArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return IntVariantArray(value)
     }
@@ -619,7 +619,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asRealVariantArray(): RealVariantArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return RealVariantArray(value)
     }
@@ -629,7 +629,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asStringVariantArray(): StringVariantArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_array)(_handle.ptr)
         }
         return StringVariantArray(value)
     }
@@ -639,7 +639,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolByteArray(): PoolByteArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_byte_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_byte_array)(_handle.ptr)
         }
         return PoolByteArray(value)
     }
@@ -649,7 +649,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolColorArray(): PoolColorArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_color_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_color_array)(_handle.ptr)
         }
         return PoolColorArray(value)
     }
@@ -659,7 +659,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolIntArray(): PoolIntArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_int_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_int_array)(_handle.ptr)
         }
         return PoolIntArray(value)
     }
@@ -669,7 +669,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolRealArray(): PoolRealArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_real_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_real_array)(_handle.ptr)
         }
         return PoolRealArray(value)
     }
@@ -679,7 +679,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolStringArray(): PoolStringArray {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_string_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_string_array)(_handle.ptr)
         }
         return PoolStringArray(value)
     }
@@ -689,7 +689,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolVector2Array(): PoolVector2Array {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_vector2_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_vector2_array)(_handle.ptr)
         }
         return PoolVector2Array(value)
     }
@@ -699,7 +699,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asPoolVector3Array(): PoolVector3Array {
         val value = memScoped {
-            checkNotNull(Godot.gdnative.godot_variant_as_pool_vector3_array)(_handle.ptr)
+            notNull(Godot.gdnative.godot_variant_as_pool_vector3_array)(_handle.ptr)
         }
         return PoolVector3Array(value)
     }
@@ -745,7 +745,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
 fun Variant() = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_nil)(this.ptr)
+            notNull(Godot.gdnative.godot_variant_new_nil)(this.ptr)
         }
     }
 )
@@ -754,7 +754,7 @@ fun Variant() = Variant(
 fun Variant(from: Boolean) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_bool)(this.ptr, from)
+            notNull(Godot.gdnative.godot_variant_new_bool)(this.ptr, from)
         }
     }
 )
@@ -762,7 +762,7 @@ fun Variant(from: Boolean) = Variant(
 fun Variant(from: Int) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.toLong())
+            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.toLong())
         }
     }
 )
@@ -770,7 +770,7 @@ fun Variant(from: Int) = Variant(
 fun <T : Enum<T>> Variant(from: Enum<T>) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.ordinal.toLong())
+            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from.ordinal.toLong())
         }
     }
 )
@@ -778,7 +778,7 @@ fun <T : Enum<T>> Variant(from: Enum<T>) = Variant(
 fun Variant(from: Long) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from)
+            notNull(Godot.gdnative.godot_variant_new_int)(this.ptr, from)
         }
     }
 )
@@ -786,7 +786,7 @@ fun Variant(from: Long) = Variant(
 fun Variant(from: Float) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from.toDouble())
+            notNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from.toDouble())
         }
     }
 )
@@ -794,7 +794,7 @@ fun Variant(from: Float) = Variant(
 fun Variant(from: Double) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from)
+            notNull(Godot.gdnative.godot_variant_new_real)(this.ptr, from)
         }
     }
 )
@@ -802,7 +802,7 @@ fun Variant(from: Double) = Variant(
 fun Variant(from: String) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().ptr)
+            notNull(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().ptr)
         }
     }
 )
@@ -812,7 +812,7 @@ fun Variant(from: String) = Variant(
 fun Variant(from: Object) = Variant(
     memScoped {
         cValue<godot_variant> {
-            checkNotNull(Godot.gdnative.godot_variant_new_object)(this.ptr, from.ptr)
+            notNull(Godot.gdnative.godot_variant_new_object)(this.ptr, from.ptr)
         }
     }
 )
@@ -828,7 +828,7 @@ internal fun <T : CPointed> wrapCore(
         memScoped {
             val ptr = core.getRawMemory(this).reinterpret<T>()
             cValue<godot_variant> {
-                checkNotNull(block)(this.ptr, ptr)
+                notNull(block)(this.ptr, ptr)
             }
         }
     )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
@@ -2,6 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
@@ -9,7 +10,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     init {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
@@ -27,19 +28,19 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun append(value: E) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: E, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: E, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -51,14 +52,14 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun count(value: E): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): EnumArray<E> {
         return EnumArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             },
             mapper
         )
@@ -66,46 +67,46 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun erase(value: E) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: E, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: E): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ))
     }
 
     override fun has(value: E): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: E) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ))
     }
@@ -113,7 +114,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun min(): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ))
     }
@@ -121,7 +122,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun popBack(): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ))
     }
@@ -129,33 +130,33 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun popFront(): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ))
     }
 
     override fun pushBack(value: E) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: E) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: E, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): EnumArray<E> {
         return EnumArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(
+                notNull(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -174,14 +175,14 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override operator fun set(idx: Int, data: E) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): E {
         return enum(Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ))
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
@@ -2,7 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
@@ -10,7 +10,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     init {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
@@ -28,19 +28,19 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun append(value: E) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: E, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: E, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -52,14 +52,14 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun count(value: E): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): EnumArray<E> {
         return EnumArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             },
             mapper
         )
@@ -67,46 +67,46 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override fun erase(value: E) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: E, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: E): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ))
     }
 
     override fun has(value: E): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: E) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ))
     }
@@ -114,7 +114,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun min(): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ))
     }
@@ -122,7 +122,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun popBack(): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ))
     }
@@ -130,33 +130,33 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
     override fun popFront(): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ))
     }
 
     override fun pushBack(value: E) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: E) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: E, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): EnumArray<E> {
         return EnumArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(
+                nullSafe(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -175,14 +175,14 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
 
     override operator fun set(idx: Int, data: E) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): E {
         return enum(Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ))
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
@@ -2,7 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 @ExperimentalUnsignedTypes
@@ -12,7 +12,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
@@ -31,19 +31,19 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override fun append(value: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: T, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: T, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -55,60 +55,60 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override fun count(value: T): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): ObjectArray<T> {
         return ObjectArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: T, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: T): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ).asObject() as T
     }
 
     override fun has(value: T): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ).asObject() as T
     }
@@ -116,7 +116,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun min(): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ).asObject() as T
     }
@@ -124,7 +124,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun popBack(): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asObject() as T
     }
@@ -133,33 +133,33 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun popFront(): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asObject() as T
     }
 
     override fun pushBack(value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: T, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): ObjectArray<T> {
         return ObjectArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                nullSafe(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -168,14 +168,14 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override operator fun set(idx: Int, data: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): T {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asObject() as T
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
@@ -2,6 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 @ExperimentalUnsignedTypes
@@ -11,7 +12,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
@@ -30,19 +31,19 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override fun append(value: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: T, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: T, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -54,60 +55,60 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override fun count(value: T): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): ObjectArray<T> {
         return ObjectArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: T, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: T): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ).asObject() as T
     }
 
     override fun has(value: T): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ).asObject() as T
     }
@@ -115,7 +116,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun min(): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ).asObject() as T
     }
@@ -123,7 +124,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun popBack(): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asObject() as T
     }
@@ -132,33 +133,33 @@ class ObjectArray<T : Object> : GodotArray<T> {
     override fun popFront(): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asObject() as T
     }
 
     override fun pushBack(value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: T, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): ObjectArray<T> {
         return ObjectArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -167,14 +168,14 @@ class ObjectArray<T : Object> : GodotArray<T> {
 
     override operator fun set(idx: Int, data: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): T {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asObject() as T
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
@@ -12,56 +12,56 @@ class VariantArray : GodotArray<Variant> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolColorArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_color_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_color_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolIntArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolRealArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolVector2Array) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_vector2_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_vector2_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolVector3Array) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_vector3_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_vector3_array)(it, other._handle.ptr)
         }
     }
 
@@ -81,7 +81,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun append(value: Variant) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value._handle.ptr)
         }
     }
 
@@ -96,7 +96,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun bsearch(value: Variant, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value._handle.ptr, before)
         }
     }
 
@@ -111,7 +111,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun bsearchCustom(value: Variant, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value._handle.ptr,
                 obj.ptr,
@@ -147,7 +147,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun count(value: Variant): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value._handle.ptr)
         }
     }
 
@@ -163,14 +163,14 @@ class VariantArray : GodotArray<Variant> {
     override fun duplicate(deep: Boolean): VariantArray {
         return VariantArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: Variant) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value._handle.ptr)
         }
     }
 
@@ -185,7 +185,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun find(what: Variant, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what._handle.ptr, from)
         }
     }
 
@@ -200,7 +200,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun findLast(value: Variant): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value._handle.ptr)
         }
     }
 
@@ -216,14 +216,14 @@ class VariantArray : GodotArray<Variant> {
     override fun front(): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         )
     }
 
     override fun has(value: Variant): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value._handle.ptr)
         }
     }
 
@@ -238,7 +238,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun insert(position: Int, value: Variant) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value._handle.ptr)
         }
     }
 
@@ -254,7 +254,7 @@ class VariantArray : GodotArray<Variant> {
     override fun max(): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         )
     }
@@ -262,7 +262,7 @@ class VariantArray : GodotArray<Variant> {
     override fun min(): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         )
     }
@@ -270,7 +270,7 @@ class VariantArray : GodotArray<Variant> {
     override fun popBack(): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         )
     }
@@ -278,14 +278,14 @@ class VariantArray : GodotArray<Variant> {
     override fun popFront(): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         )
     }
 
     override fun pushBack(value: Variant) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value._handle.ptr)
         }
     }
 
@@ -300,7 +300,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun pushFront(value: Variant) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value._handle.ptr)
         }
     }
 
@@ -315,7 +315,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun rfind(what: Variant, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what._handle.ptr, from)
         }
     }
 
@@ -331,7 +331,7 @@ class VariantArray : GodotArray<Variant> {
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): VariantArray {
         return VariantArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -342,7 +342,7 @@ class VariantArray : GodotArray<Variant> {
 
     override operator fun set(idx: Int, data: Variant) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, data._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, data._handle.ptr)
         }
     }
 
@@ -359,7 +359,7 @@ class VariantArray : GodotArray<Variant> {
     override operator fun get(idx: Int): Variant {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         )
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
@@ -12,56 +12,56 @@ class VariantArray : GodotArray<Variant> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolColorArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_color_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_color_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolIntArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolRealArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolVector2Array) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_vector2_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_vector2_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolVector3Array) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_vector3_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_vector3_array)(it, other._handle.ptr)
         }
     }
 
@@ -81,7 +81,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun append(value: Variant) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value._handle.ptr)
         }
     }
 
@@ -96,7 +96,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun bsearch(value: Variant, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value._handle.ptr, before)
         }
     }
 
@@ -111,7 +111,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun bsearchCustom(value: Variant, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value._handle.ptr,
                 obj.ptr,
@@ -147,7 +147,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun count(value: Variant): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value._handle.ptr)
         }
     }
 
@@ -163,14 +163,14 @@ class VariantArray : GodotArray<Variant> {
     override fun duplicate(deep: Boolean): VariantArray {
         return VariantArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: Variant) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value._handle.ptr)
         }
     }
 
@@ -185,7 +185,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun find(what: Variant, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what._handle.ptr, from)
         }
     }
 
@@ -200,7 +200,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun findLast(value: Variant): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value._handle.ptr)
         }
     }
 
@@ -216,14 +216,14 @@ class VariantArray : GodotArray<Variant> {
     override fun front(): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         )
     }
 
     override fun has(value: Variant): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value._handle.ptr)
         }
     }
 
@@ -238,7 +238,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun insert(position: Int, value: Variant) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value._handle.ptr)
         }
     }
 
@@ -254,7 +254,7 @@ class VariantArray : GodotArray<Variant> {
     override fun max(): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         )
     }
@@ -262,7 +262,7 @@ class VariantArray : GodotArray<Variant> {
     override fun min(): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         )
     }
@@ -270,7 +270,7 @@ class VariantArray : GodotArray<Variant> {
     override fun popBack(): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         )
     }
@@ -278,14 +278,14 @@ class VariantArray : GodotArray<Variant> {
     override fun popFront(): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         )
     }
 
     override fun pushBack(value: Variant) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value._handle.ptr)
         }
     }
 
@@ -300,7 +300,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun pushFront(value: Variant) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value._handle.ptr)
         }
     }
 
@@ -315,7 +315,7 @@ class VariantArray : GodotArray<Variant> {
 
     override fun rfind(what: Variant, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what._handle.ptr, from)
         }
     }
 
@@ -331,7 +331,7 @@ class VariantArray : GodotArray<Variant> {
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): VariantArray {
         return VariantArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                nullSafe(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -342,7 +342,7 @@ class VariantArray : GodotArray<Variant> {
 
     override operator fun set(idx: Int, data: Variant) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, data._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, data._handle.ptr)
         }
     }
 
@@ -359,7 +359,7 @@ class VariantArray : GodotArray<Variant> {
     override operator fun get(idx: Int): Variant {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         )
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
@@ -12,14 +12,14 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: CoreArray<T>) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -37,19 +37,19 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun append(value: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: T, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: T, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -61,33 +61,33 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun count(value: T): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): CoreArray<T> {
         return getCoreArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: T, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: T): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
@@ -95,7 +95,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative.godot_array_front)(it)
+                    notNull(Godot.gdnative.godot_array_front)(it)
                 }
             )
         )
@@ -103,13 +103,13 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun has(value: T): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
@@ -117,7 +117,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                    notNull(Godot.gdnative11.godot_array_max)(it)
                 }
             )
         )
@@ -127,7 +127,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                    notNull(Godot.gdnative11.godot_array_min)(it)
                 }
             )
         )
@@ -137,7 +137,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                    notNull(Godot.gdnative.godot_array_pop_back)(it)
                 }
             )
         )
@@ -148,7 +148,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                    notNull(Godot.gdnative.godot_array_pop_front)(it)
                 }
             )
         )
@@ -156,26 +156,26 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun pushBack(value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: T) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: T, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): CoreArray<T> {
         return getCoreArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -186,7 +186,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override operator fun set(idx: Int, data: T) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, data.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, data.toVariant()._handle.ptr)
         }
     }
 
@@ -194,7 +194,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                    notNull(Godot.gdnative.godot_array_get)(it, idx)
                 }
             )
         )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
@@ -12,14 +12,14 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: CoreArray<T>) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -37,19 +37,19 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun append(value: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: T, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: T, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -61,33 +61,33 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun count(value: T): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): CoreArray<T> {
         return getCoreArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: T, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: T): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
@@ -95,7 +95,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative.godot_array_front)(it)
+                    nullSafe(Godot.gdnative.godot_array_front)(it)
                 }
             )
         )
@@ -103,13 +103,13 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun has(value: T): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
@@ -117,7 +117,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative11.godot_array_max)(it)
+                    nullSafe(Godot.gdnative11.godot_array_max)(it)
                 }
             )
         )
@@ -127,7 +127,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative11.godot_array_min)(it)
+                    nullSafe(Godot.gdnative11.godot_array_min)(it)
                 }
             )
         )
@@ -137,7 +137,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative.godot_array_pop_back)(it)
+                    nullSafe(Godot.gdnative.godot_array_pop_back)(it)
                 }
             )
         )
@@ -148,7 +148,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative.godot_array_pop_front)(it)
+                    nullSafe(Godot.gdnative.godot_array_pop_front)(it)
                 }
             )
         )
@@ -156,26 +156,26 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override fun pushBack(value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: T) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: T, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): CoreArray<T> {
         return getCoreArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
+                nullSafe(Godot.gdnative12.godot_array_slice)(it, begin, end, step, deep)
             }
         )
     }
@@ -186,7 +186,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
 
     override operator fun set(idx: Int, data: T) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, data.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, data.toVariant()._handle.ptr)
         }
     }
 
@@ -194,7 +194,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
         return getCore(
             Variant(
                 callNative {
-                    notNull(Godot.gdnative.godot_array_get)(it, idx)
+                    nullSafe(Godot.gdnative.godot_array_get)(it, idx)
                 }
             )
         )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
@@ -2,6 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 class BoolVariantArray : GodotArray<Boolean> {
@@ -10,14 +11,14 @@ class BoolVariantArray : GodotArray<Boolean> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: BoolVariantArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -36,19 +37,19 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override fun append(value: Boolean) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: Boolean, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: Boolean, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -60,60 +61,60 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override fun count(value: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): BoolVariantArray {
         return BoolVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: Boolean) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: Boolean, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ).asBoolean()
     }
 
     override fun has(value: Boolean): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: Boolean) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ).asBoolean()
     }
@@ -121,7 +122,7 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun min(): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ).asBoolean()
     }
@@ -129,7 +130,7 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun popBack(): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asBoolean()
     }
@@ -138,33 +139,33 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun popFront(): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asBoolean()
     }
 
     override fun pushBack(value: Boolean) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: Boolean) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: Boolean, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): BoolVariantArray {
         return BoolVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(
+                notNull(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -179,14 +180,14 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override operator fun set(idx: Int, data: Boolean) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): Boolean {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asBoolean()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
@@ -2,7 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 class BoolVariantArray : GodotArray<Boolean> {
@@ -11,14 +11,14 @@ class BoolVariantArray : GodotArray<Boolean> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: BoolVariantArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -37,19 +37,19 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override fun append(value: Boolean) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: Boolean, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: Boolean, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -61,60 +61,60 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override fun count(value: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): BoolVariantArray {
         return BoolVariantArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: Boolean) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: Boolean, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ).asBoolean()
     }
 
     override fun has(value: Boolean): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: Boolean) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ).asBoolean()
     }
@@ -122,7 +122,7 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun min(): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ).asBoolean()
     }
@@ -130,7 +130,7 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun popBack(): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asBoolean()
     }
@@ -139,33 +139,33 @@ class BoolVariantArray : GodotArray<Boolean> {
     override fun popFront(): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asBoolean()
     }
 
     override fun pushBack(value: Boolean) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: Boolean) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: Boolean, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): BoolVariantArray {
         return BoolVariantArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(
+                nullSafe(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -180,14 +180,14 @@ class BoolVariantArray : GodotArray<Boolean> {
 
     override operator fun set(idx: Int, data: Boolean) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): Boolean {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asBoolean()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
@@ -3,6 +3,7 @@ package godot.core
 import godot.Object
 import godot.gdnative.godot_array
 import godot.internal.type.NaturalT
+import godot.internal.type.notNull
 import godot.internal.type.toNaturalT
 import kotlinx.cinterop.*
 
@@ -12,28 +13,28 @@ class IntVariantArray : GodotArray<NaturalT> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: IntVariantArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolIntArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
         }
     }
 
@@ -52,19 +53,19 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override fun append(value: NaturalT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: NaturalT, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: NaturalT, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -76,60 +77,60 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override fun count(value: NaturalT): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): IntVariantArray {
         return IntVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: NaturalT, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: NaturalT): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ).asLong().toNaturalT()
     }
 
     override fun has(value: NaturalT): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: NaturalT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ).asLong().toNaturalT()
     }
@@ -137,7 +138,7 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun min(): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ).asInt().toNaturalT()
     }
@@ -145,7 +146,7 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun popBack(): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asInt().toNaturalT()
     }
@@ -153,33 +154,33 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun popFront(): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asInt().toNaturalT()
     }
 
     override fun pushBack(value: NaturalT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: NaturalT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: NaturalT, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): IntVariantArray {
         return IntVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(
+                notNull(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -194,14 +195,14 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override operator fun set(idx: Int, data: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): NaturalT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asInt().toNaturalT()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
@@ -3,7 +3,7 @@ package godot.core
 import godot.Object
 import godot.gdnative.godot_array
 import godot.internal.type.NaturalT
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import godot.internal.type.toNaturalT
 import kotlinx.cinterop.*
 
@@ -13,28 +13,28 @@ class IntVariantArray : GodotArray<NaturalT> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: IntVariantArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_byte_array)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolIntArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_int_array)(it, other._handle.ptr)
         }
     }
 
@@ -53,19 +53,19 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override fun append(value: NaturalT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: NaturalT, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: NaturalT, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -77,60 +77,60 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override fun count(value: NaturalT): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): IntVariantArray {
         return IntVariantArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: NaturalT, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: NaturalT): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ).asLong().toNaturalT()
     }
 
     override fun has(value: NaturalT): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: NaturalT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ).asLong().toNaturalT()
     }
@@ -138,7 +138,7 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun min(): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ).asInt().toNaturalT()
     }
@@ -146,7 +146,7 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun popBack(): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asInt().toNaturalT()
     }
@@ -154,33 +154,33 @@ class IntVariantArray : GodotArray<NaturalT> {
     override fun popFront(): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asInt().toNaturalT()
     }
 
     override fun pushBack(value: NaturalT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: NaturalT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: NaturalT, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): IntVariantArray {
         return IntVariantArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(
+                nullSafe(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -195,14 +195,14 @@ class IntVariantArray : GodotArray<NaturalT> {
 
     override operator fun set(idx: Int, data: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): NaturalT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asInt().toNaturalT()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
@@ -3,7 +3,7 @@ package godot.core
 import godot.Object
 import godot.gdnative.godot_array
 import godot.internal.type.RealT
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import godot.internal.type.toRealT
 import kotlinx.cinterop.*
 
@@ -13,21 +13,21 @@ class RealVariantArray : GodotArray<RealT> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: RealVariantArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolRealArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
         }
     }
 
@@ -46,19 +46,19 @@ class RealVariantArray : GodotArray<RealT> {
 
     override fun append(value: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: RealT, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: RealT, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -70,60 +70,60 @@ class RealVariantArray : GodotArray<RealT> {
 
     override fun count(value: RealT): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): RealVariantArray {
         return RealVariantArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: RealT, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: RealT): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ).asDouble().toRealT()
     }
 
     override fun has(value: RealT): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: RealT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ).asDouble().toRealT()
     }
@@ -131,7 +131,7 @@ class RealVariantArray : GodotArray<RealT> {
     override fun min(): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ).asDouble().toRealT()
     }
@@ -139,7 +139,7 @@ class RealVariantArray : GodotArray<RealT> {
     override fun popBack(): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asDouble().toRealT()
     }
@@ -148,33 +148,33 @@ class RealVariantArray : GodotArray<RealT> {
     override fun popFront(): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asDouble().toRealT()
     }
 
     override fun pushBack(value: RealT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: RealT) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: RealT, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): RealVariantArray {
         return RealVariantArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(
+                nullSafe(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -189,14 +189,14 @@ class RealVariantArray : GodotArray<RealT> {
 
     override operator fun set(idx: Int, data: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): RealT {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asDouble().toRealT()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
@@ -3,6 +3,7 @@ package godot.core
 import godot.Object
 import godot.gdnative.godot_array
 import godot.internal.type.RealT
+import godot.internal.type.notNull
 import godot.internal.type.toRealT
 import kotlinx.cinterop.*
 
@@ -12,21 +13,21 @@ class RealVariantArray : GodotArray<RealT> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: RealVariantArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolRealArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_real_array)(it, other._handle.ptr)
         }
     }
 
@@ -45,19 +46,19 @@ class RealVariantArray : GodotArray<RealT> {
 
     override fun append(value: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: RealT, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: RealT, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -69,60 +70,60 @@ class RealVariantArray : GodotArray<RealT> {
 
     override fun count(value: RealT): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): RealVariantArray {
         return RealVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: RealT, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: RealT): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ).asDouble().toRealT()
     }
 
     override fun has(value: RealT): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: RealT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ).asDouble().toRealT()
     }
@@ -130,7 +131,7 @@ class RealVariantArray : GodotArray<RealT> {
     override fun min(): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ).asDouble().toRealT()
     }
@@ -138,7 +139,7 @@ class RealVariantArray : GodotArray<RealT> {
     override fun popBack(): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asDouble().toRealT()
     }
@@ -147,33 +148,33 @@ class RealVariantArray : GodotArray<RealT> {
     override fun popFront(): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asDouble().toRealT()
     }
 
     override fun pushBack(value: RealT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: RealT) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: RealT, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): RealVariantArray {
         return RealVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(
+                notNull(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -188,14 +189,14 @@ class RealVariantArray : GodotArray<RealT> {
 
     override operator fun set(idx: Int, data: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): RealT {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asDouble().toRealT()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
@@ -2,6 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
+import godot.internal.type.notNull
 import kotlinx.cinterop.*
 
 class StringVariantArray : GodotArray<String> {
@@ -10,21 +11,21 @@ class StringVariantArray : GodotArray<String> {
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new)(it)
+            notNull(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: StringVariantArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
         }
     }
 
@@ -43,19 +44,19 @@ class StringVariantArray : GodotArray<String> {
 
     override fun append(value: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: String, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_bsearch_custom)(
+            notNull(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -67,60 +68,60 @@ class StringVariantArray : GodotArray<String> {
 
     override fun count(value: String): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): StringVariantArray {
         return StringVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: String, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: String): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_front)(it)
+                notNull(Godot.gdnative.godot_array_front)(it)
             }
         ).asString()
     }
 
     override fun has(value: String): Boolean {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: String) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_max)(it)
+                notNull(Godot.gdnative11.godot_array_max)(it)
             }
         ).asString()
     }
@@ -128,7 +129,7 @@ class StringVariantArray : GodotArray<String> {
     override fun min(): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative11.godot_array_min)(it)
+                notNull(Godot.gdnative11.godot_array_min)(it)
             }
         ).asString()
     }
@@ -136,7 +137,7 @@ class StringVariantArray : GodotArray<String> {
     override fun popBack(): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_back)(it)
+                notNull(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asString()
     }
@@ -145,33 +146,33 @@ class StringVariantArray : GodotArray<String> {
     override fun popFront(): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_pop_front)(it)
+                notNull(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asString()
     }
 
     override fun pushBack(value: String) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: String) {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: String, from: Int): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): StringVariantArray {
         return StringVariantArray(
             callNative {
-                checkNotNull(Godot.gdnative12.godot_array_slice)(
+                notNull(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -186,14 +187,14 @@ class StringVariantArray : GodotArray<String> {
 
     override operator fun set(idx: Int, data: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): String {
         return Variant(
             callNative {
-                checkNotNull(Godot.gdnative.godot_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asString()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
@@ -2,7 +2,7 @@ package godot.core
 
 import godot.Object
 import godot.gdnative.godot_array
-import godot.internal.type.notNull
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
 class StringVariantArray : GodotArray<String> {
@@ -11,21 +11,21 @@ class StringVariantArray : GodotArray<String> {
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new)(it)
+            nullSafe(Godot.gdnative.godot_array_new)(it)
         }
     }
 
     constructor(other: StringVariantArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_copy)(it, other._handle.ptr)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_new_pool_string_array)(it, other._handle.ptr)
         }
     }
 
@@ -44,19 +44,19 @@ class StringVariantArray : GodotArray<String> {
 
     override fun append(value: String) {
         callNative {
-            notNull(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_append)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun bsearch(value: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
+            nullSafe(Godot.gdnative.godot_array_bsearch)(it, value.toVariant()._handle.ptr, before)
         }
     }
 
     override fun bsearchCustom(value: String, obj: Object, func: String, before: Boolean): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_bsearch_custom)(
+            nullSafe(Godot.gdnative.godot_array_bsearch_custom)(
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
@@ -68,60 +68,60 @@ class StringVariantArray : GodotArray<String> {
 
     override fun count(value: String): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_count)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun duplicate(deep: Boolean): StringVariantArray {
         return StringVariantArray(
             callNative {
-                notNull(Godot.gdnative11.godot_array_duplicate)(it, deep)
+                nullSafe(Godot.gdnative11.godot_array_duplicate)(it, deep)
             }
         )
     }
 
     override fun erase(value: String) {
         callNative {
-            notNull(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_erase)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun find(what: String, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_find)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun findLast(value: String): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_find_last)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun front(): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_front)(it)
+                nullSafe(Godot.gdnative.godot_array_front)(it)
             }
         ).asString()
     }
 
     override fun has(value: String): Boolean {
         return callNative {
-            notNull(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_has)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun insert(position: Int, value: String) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_insert)(it, position, value.toVariant()._handle.ptr)
         }
     }
 
     override fun max(): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_max)(it)
+                nullSafe(Godot.gdnative11.godot_array_max)(it)
             }
         ).asString()
     }
@@ -129,7 +129,7 @@ class StringVariantArray : GodotArray<String> {
     override fun min(): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative11.godot_array_min)(it)
+                nullSafe(Godot.gdnative11.godot_array_min)(it)
             }
         ).asString()
     }
@@ -137,7 +137,7 @@ class StringVariantArray : GodotArray<String> {
     override fun popBack(): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_back)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_back)(it)
             }
         ).asString()
     }
@@ -146,33 +146,33 @@ class StringVariantArray : GodotArray<String> {
     override fun popFront(): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_pop_front)(it)
+                nullSafe(Godot.gdnative.godot_array_pop_front)(it)
             }
         ).asString()
     }
 
     override fun pushBack(value: String) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_back)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun pushFront(value: String) {
         return callNative {
-            notNull(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_push_front)(it, value.toVariant()._handle.ptr)
         }
     }
 
     override fun rfind(what: String, from: Int): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
+            nullSafe(Godot.gdnative.godot_array_rfind)(it, what.toVariant()._handle.ptr, from)
         }
     }
 
     override fun slice(begin: Int, end: Int, step: Int, deep: Boolean): StringVariantArray {
         return StringVariantArray(
             callNative {
-                notNull(Godot.gdnative12.godot_array_slice)(
+                nullSafe(Godot.gdnative12.godot_array_slice)(
                     it,
                     begin,
                     end,
@@ -187,14 +187,14 @@ class StringVariantArray : GodotArray<String> {
 
     override operator fun set(idx: Int, data: String) {
         callNative {
-            notNull(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
+            nullSafe(Godot.gdnative.godot_array_set)(it, idx, Variant(data)._handle.ptr)
         }
     }
 
     override operator fun get(idx: Int): String {
         return Variant(
             callNative {
-                notNull(Godot.gdnative.godot_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_array_get)(it, idx)
             }
         ).asString()
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolByteArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolByteArray.kt
@@ -2,7 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_pool_byte_array
 import godot.gdnative.godot_pool_byte_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,14 +16,14 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_new)(it)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +53,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun append(byte: UByte) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_append)(it, byte)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_append)(it, byte)
         }
     }
 
@@ -64,7 +63,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun appendArray(array: PoolByteArray) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +72,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_byte_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_byte_array_empty)(it)
         }
     }
 
@@ -82,7 +81,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     operator fun get(idx: Int): UByte {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_get)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_get)(it, idx)
         }
     }
 
@@ -92,7 +91,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun insert(idx: Int, data: UByte) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_insert)(it, idx, data)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_insert)(it, idx, data)
         }
     }
 
@@ -101,7 +100,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_invert)(it)
         }
     }
 
@@ -110,7 +109,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun pushBack(data: UByte) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_push_back)(it, data)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_push_back)(it, data)
         }
     }
 
@@ -119,7 +118,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_remove)(it, idx)
         }
     }
 
@@ -129,7 +128,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_resize)(it, size)
         }
     }
 
@@ -138,7 +137,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     operator fun set(idx: Int, data: UByte) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_set)(it, idx, data)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_set)(it, idx, data)
         }
     }
 
@@ -147,7 +146,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_byte_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_byte_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolByteArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolByteArray.kt
@@ -17,14 +17,14 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_byte_array_new)(it)
         }
     }
 
     constructor(other: PoolByteArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_byte_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +54,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun append(byte: UByte) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_append)(it, byte)
+            notNull(Godot.gdnative.godot_pool_byte_array_append)(it, byte)
         }
     }
 
@@ -64,7 +64,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun appendArray(array: PoolByteArray) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_byte_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +73,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_byte_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_byte_array_empty)(it)
         }
     }
 
@@ -82,7 +82,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     operator fun get(idx: Int): UByte {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_get)(it, idx)
+            notNull(Godot.gdnative.godot_pool_byte_array_get)(it, idx)
         }
     }
 
@@ -92,7 +92,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun insert(idx: Int, data: UByte) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_insert)(it, idx, data)
+            notNull(Godot.gdnative.godot_pool_byte_array_insert)(it, idx, data)
         }
     }
 
@@ -101,7 +101,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_byte_array_invert)(it)
         }
     }
 
@@ -110,7 +110,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun pushBack(data: UByte) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_push_back)(it, data)
+            notNull(Godot.gdnative.godot_pool_byte_array_push_back)(it, data)
         }
     }
 
@@ -119,7 +119,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_byte_array_remove)(it, idx)
         }
     }
 
@@ -129,7 +129,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_byte_array_resize)(it, size)
         }
     }
 
@@ -138,7 +138,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     operator fun set(idx: Int, data: UByte) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_set)(it, idx, data)
+            notNull(Godot.gdnative.godot_pool_byte_array_set)(it, idx, data)
         }
     }
 
@@ -147,7 +147,7 @@ class PoolByteArray : NativeCoreType<godot_pool_byte_array_layout>, Iterable<UBy
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_byte_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_byte_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolColorArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolColorArray.kt
@@ -2,8 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_aabb
-import godot.gdnative.godot_pool_color_array
 import godot.gdnative.godot_pool_color_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -18,7 +16,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_color_array_new)(it)
         }
     }
 
@@ -48,7 +46,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun append(color: Color) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_append)(it, color.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_color_array_append)(it, color.getRawMemory(this).reinterpret())
         }
     }
 
@@ -58,7 +56,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun appendArray(array: PoolColorArray) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_color_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -67,7 +65,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_color_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_color_array_empty)(it)
         }
     }
 
@@ -77,7 +75,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
     operator fun get(idx: Int): Color {
         return Color(
             callNative {
-                notNull(Godot.gdnative.godot_pool_color_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_pool_color_array_get)(it, idx)
             }
         )
     }
@@ -88,7 +86,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun insert(idx: Int, data: Color) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_color_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -97,7 +95,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_color_array_invert)(it)
         }
     }
 
@@ -106,7 +104,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun pushBack(data: Color) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_color_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -115,7 +113,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_color_array_remove)(it, idx)
         }
     }
 
@@ -125,7 +123,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_color_array_resize)(it, size)
         }
     }
 
@@ -134,7 +132,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     operator fun set(idx: Int, data: Color) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_color_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -143,7 +141,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_color_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_color_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolColorArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolColorArray.kt
@@ -18,7 +18,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_color_array_new)(it)
         }
     }
 
@@ -48,7 +48,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun append(color: Color) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_append)(it, color.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_color_array_append)(it, color.getRawMemory(this).reinterpret())
         }
     }
 
@@ -58,7 +58,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun appendArray(array: PoolColorArray) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_color_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -67,7 +67,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_color_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_color_array_empty)(it)
         }
     }
 
@@ -77,7 +77,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
     operator fun get(idx: Int): Color {
         return Color(
             callNative {
-                checkNotNull(Godot.gdnative.godot_pool_color_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_pool_color_array_get)(it, idx)
             }
         )
     }
@@ -88,7 +88,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun insert(idx: Int, data: Color) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_color_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -97,7 +97,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_color_array_invert)(it)
         }
     }
 
@@ -106,7 +106,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun pushBack(data: Color) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_color_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -115,7 +115,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_color_array_remove)(it, idx)
         }
     }
 
@@ -125,7 +125,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_color_array_resize)(it, size)
         }
     }
 
@@ -134,7 +134,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     operator fun set(idx: Int, data: Color) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_color_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -143,7 +143,7 @@ class PoolColorArray : NativeCoreType<godot_pool_color_array_layout>, Iterable<C
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_color_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_color_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolIntArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolIntArray.kt
@@ -18,7 +18,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_int_array_new)(it)
         }
     }
 
@@ -48,7 +48,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun append(i: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_append)(it, i.toGodotNatural())
+            notNull(Godot.gdnative.godot_pool_int_array_append)(it, i.toGodotNatural())
         }
     }
 
@@ -58,7 +58,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun appendArray(array: PoolIntArray) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_int_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -67,7 +67,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_int_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_int_array_empty)(it)
         }
     }
 
@@ -76,7 +76,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     operator fun get(idx: Int): NaturalT {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_get)(it, idx).toNaturalT()
+            notNull(Godot.gdnative.godot_pool_int_array_get)(it, idx).toNaturalT()
         }
     }
 
@@ -86,7 +86,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun insert(idx: Int, data: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_insert)(it, idx, data.toGodotNatural())
+            notNull(Godot.gdnative.godot_pool_int_array_insert)(it, idx, data.toGodotNatural())
         }
     }
 
@@ -95,7 +95,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_int_array_invert)(it)
         }
     }
 
@@ -104,7 +104,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun pushBack(data: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_push_back)(it, data.toGodotNatural())
+            notNull(Godot.gdnative.godot_pool_int_array_push_back)(it, data.toGodotNatural())
         }
     }
 
@@ -113,7 +113,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_int_array_remove)(it, idx)
         }
     }
 
@@ -123,7 +123,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_int_array_resize)(it, size)
         }
     }
 
@@ -132,7 +132,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     operator fun set(idx: Int, data: NaturalT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_set)(it, idx, data.toGodotNatural())
+            notNull(Godot.gdnative.godot_pool_int_array_set)(it, idx, data.toGodotNatural())
         }
     }
 
@@ -141,7 +141,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_int_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_int_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolIntArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolIntArray.kt
@@ -2,8 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_aabb
-import godot.gdnative.godot_pool_int_array
 import godot.gdnative.godot_pool_int_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -18,7 +16,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_int_array_new)(it)
         }
     }
 
@@ -48,7 +46,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun append(i: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_append)(it, i.toGodotNatural())
+            nullSafe(Godot.gdnative.godot_pool_int_array_append)(it, i.toGodotNatural())
         }
     }
 
@@ -58,7 +56,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun appendArray(array: PoolIntArray) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_int_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -67,7 +65,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_int_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_int_array_empty)(it)
         }
     }
 
@@ -76,7 +74,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     operator fun get(idx: Int): NaturalT {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_get)(it, idx).toNaturalT()
+            nullSafe(Godot.gdnative.godot_pool_int_array_get)(it, idx).toNaturalT()
         }
     }
 
@@ -86,7 +84,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun insert(idx: Int, data: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_insert)(it, idx, data.toGodotNatural())
+            nullSafe(Godot.gdnative.godot_pool_int_array_insert)(it, idx, data.toGodotNatural())
         }
     }
 
@@ -95,7 +93,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_int_array_invert)(it)
         }
     }
 
@@ -104,7 +102,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun pushBack(data: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_push_back)(it, data.toGodotNatural())
+            nullSafe(Godot.gdnative.godot_pool_int_array_push_back)(it, data.toGodotNatural())
         }
     }
 
@@ -113,7 +111,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_int_array_remove)(it, idx)
         }
     }
 
@@ -123,7 +121,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_int_array_resize)(it, size)
         }
     }
 
@@ -132,7 +130,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     operator fun set(idx: Int, data: NaturalT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_set)(it, idx, data.toGodotNatural())
+            nullSafe(Godot.gdnative.godot_pool_int_array_set)(it, idx, data.toGodotNatural())
         }
     }
 
@@ -141,7 +139,7 @@ class PoolIntArray : NativeCoreType<godot_pool_int_array_layout>, Iterable<Natur
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_int_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_int_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolRealArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolRealArray.kt
@@ -2,7 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_pool_real_array
 import godot.gdnative.godot_pool_real_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,7 +16,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_real_array_new)(it)
         }
     }
 
@@ -47,7 +46,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun append(real: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_append)(it, real.toFloat())
+            nullSafe(Godot.gdnative.godot_pool_real_array_append)(it, real.toFloat())
         }
     }
 
@@ -57,7 +56,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun appendArray(array: PoolRealArray) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_real_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -66,7 +65,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_real_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_real_array_empty)(it)
         }
     }
 
@@ -75,7 +74,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     operator fun get(idx: Int): RealT {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_get)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_real_array_get)(it, idx)
         }.toRealT()
     }
 
@@ -85,7 +84,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun insert(idx: Int, data: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_insert)(it, idx, data.toFloat())
+            nullSafe(Godot.gdnative.godot_pool_real_array_insert)(it, idx, data.toFloat())
         }
     }
 
@@ -94,7 +93,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_real_array_invert)(it)
         }
     }
 
@@ -103,7 +102,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun pushBack(data: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_push_back)(it, data.toFloat())
+            nullSafe(Godot.gdnative.godot_pool_real_array_push_back)(it, data.toFloat())
         }
     }
 
@@ -112,7 +111,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_real_array_remove)(it, idx)
         }
     }
 
@@ -122,7 +121,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_real_array_resize)(it, size)
         }
     }
 
@@ -131,7 +130,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     operator fun set(idx: Int, data: RealT) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_set)(it, idx, data.toFloat())
+            nullSafe(Godot.gdnative.godot_pool_real_array_set)(it, idx, data.toFloat())
         }
     }
 
@@ -140,7 +139,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_real_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_real_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolRealArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolRealArray.kt
@@ -17,7 +17,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_real_array_new)(it)
         }
     }
 
@@ -47,7 +47,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun append(real: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_append)(it, real.toFloat())
+            notNull(Godot.gdnative.godot_pool_real_array_append)(it, real.toFloat())
         }
     }
 
@@ -57,7 +57,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun appendArray(array: PoolRealArray) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_real_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -66,7 +66,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_real_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_real_array_empty)(it)
         }
     }
 
@@ -75,7 +75,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     operator fun get(idx: Int): RealT {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_get)(it, idx)
+            notNull(Godot.gdnative.godot_pool_real_array_get)(it, idx)
         }.toRealT()
     }
 
@@ -85,7 +85,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun insert(idx: Int, data: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_insert)(it, idx, data.toFloat())
+            notNull(Godot.gdnative.godot_pool_real_array_insert)(it, idx, data.toFloat())
         }
     }
 
@@ -94,7 +94,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_real_array_invert)(it)
         }
     }
 
@@ -103,7 +103,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun pushBack(data: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_push_back)(it, data.toFloat())
+            notNull(Godot.gdnative.godot_pool_real_array_push_back)(it, data.toFloat())
         }
     }
 
@@ -112,7 +112,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_real_array_remove)(it, idx)
         }
     }
 
@@ -122,7 +122,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_real_array_resize)(it, size)
         }
     }
 
@@ -131,7 +131,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     operator fun set(idx: Int, data: RealT) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_set)(it, idx, data.toFloat())
+            notNull(Godot.gdnative.godot_pool_real_array_set)(it, idx, data.toFloat())
         }
     }
 
@@ -140,7 +140,7 @@ class PoolRealArray : NativeCoreType<godot_pool_real_array_layout>, Iterable<Rea
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_real_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_real_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
@@ -17,14 +17,14 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_string_array_new)(it)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +54,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun append(s: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().ptr)
         }
     }
 
@@ -64,7 +64,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun appendArray(array: PoolStringArray) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +73,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_string_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_string_array_empty)(it)
         }
     }
 
@@ -82,7 +82,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun get(idx: Int): String {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_get)(it, idx)
+            notNull(Godot.gdnative.godot_pool_string_array_get)(it, idx)
         }.toKString()
     }
 
@@ -92,7 +92,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun insert(idx: Int, data: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().ptr)
         }
     }
 
@@ -101,7 +101,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_string_array_invert)(it)
         }
     }
 
@@ -110,7 +110,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun pushBack(data: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().ptr)
         }
     }
 
@@ -119,7 +119,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_string_array_remove)(it, idx)
         }
     }
 
@@ -129,7 +129,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_string_array_resize)(it, size)
         }
     }
 
@@ -138,7 +138,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun set(idx: Int, data: String) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().ptr)
+            notNull(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().ptr)
         }
     }
 
@@ -147,7 +147,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_string_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_string_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
@@ -2,7 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_pool_string_array
 import godot.gdnative.godot_pool_string_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,14 +16,14 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_string_array_new)(it)
         }
     }
 
     constructor(other: PoolStringArray) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +53,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun append(s: String) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().ptr)
         }
     }
 
@@ -64,7 +63,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun appendArray(array: PoolStringArray) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +72,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_string_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_string_array_empty)(it)
         }
     }
 
@@ -82,7 +81,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun get(idx: Int): String {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_get)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_string_array_get)(it, idx)
         }.toKString()
     }
 
@@ -92,7 +91,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun insert(idx: Int, data: String) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().ptr)
         }
     }
 
@@ -101,7 +100,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_string_array_invert)(it)
         }
     }
 
@@ -110,7 +109,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun pushBack(data: String) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().ptr)
         }
     }
 
@@ -119,7 +118,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_string_array_remove)(it, idx)
         }
     }
 
@@ -129,7 +128,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_string_array_resize)(it, size)
         }
     }
 
@@ -138,7 +137,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun set(idx: Int, data: String) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().ptr)
         }
     }
 
@@ -147,7 +146,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_string_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_string_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector2Array.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector2Array.kt
@@ -17,14 +17,14 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_vector2_array_new)(it)
         }
     }
 
     constructor(other: PoolVector2Array) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_vector2_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +54,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun append(vector: Vector2) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_append)(it, vector.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector2_array_append)(it, vector.getRawMemory(this).reinterpret())
         }
     }
 
@@ -64,7 +64,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun appendArray(array: PoolVector2Array) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_vector2_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +73,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_vector2_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_vector2_array_empty)(it)
         }
     }
 
@@ -83,7 +83,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
     operator fun get(idx: Int): Vector2 {
         return Vector2(
             callNative {
-                checkNotNull(Godot.gdnative.godot_pool_vector2_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_pool_vector2_array_get)(it, idx)
             }
         )
     }
@@ -94,7 +94,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun insert(idx: Int, data: Vector2) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector2_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -103,7 +103,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_vector2_array_invert)(it)
         }
     }
 
@@ -112,7 +112,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun pushBack(data: Vector2) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector2_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -121,7 +121,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_vector2_array_remove)(it, idx)
         }
     }
 
@@ -131,7 +131,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_vector2_array_resize)(it, size)
         }
     }
 
@@ -140,7 +140,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     operator fun set(idx: Int, data: Vector2) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector2_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -149,7 +149,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector2_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_vector2_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector2Array.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector2Array.kt
@@ -2,7 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_pool_vector2_array
 import godot.gdnative.godot_pool_vector2_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,14 +16,14 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_new)(it)
         }
     }
 
     constructor(other: PoolVector2Array) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +53,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun append(vector: Vector2) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_append)(it, vector.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_append)(it, vector.getRawMemory(this).reinterpret())
         }
     }
 
@@ -64,7 +63,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun appendArray(array: PoolVector2Array) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +72,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_vector2_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_vector2_array_empty)(it)
         }
     }
 
@@ -83,7 +82,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
     operator fun get(idx: Int): Vector2 {
         return Vector2(
             callNative {
-                notNull(Godot.gdnative.godot_pool_vector2_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_pool_vector2_array_get)(it, idx)
             }
         )
     }
@@ -94,7 +93,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun insert(idx: Int, data: Vector2) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -103,7 +102,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_invert)(it)
         }
     }
 
@@ -112,7 +111,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun pushBack(data: Vector2) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -121,7 +120,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_remove)(it, idx)
         }
     }
 
@@ -131,7 +130,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_resize)(it, size)
         }
     }
 
@@ -140,7 +139,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     operator fun set(idx: Int, data: Vector2) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -149,7 +148,7 @@ class PoolVector2Array : NativeCoreType<godot_pool_vector2_array_layout>, Iterab
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_vector2_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector2_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector3Array.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector3Array.kt
@@ -17,14 +17,14 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
     constructor() {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_new)(it)
+            notNull(Godot.gdnative.godot_pool_vector3_array_new)(it)
         }
     }
 
     constructor(other: PoolVector3Array) {
         _handle = cValue{}
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_new_copy)(it, other._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_vector3_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +54,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun append(vector: Vector3) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_append)(it, vector.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector3_array_append)(it, vector.getRawMemory(this).reinterpret())
         }
     }
 
@@ -64,7 +64,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun appendArray(array: PoolVector3Array) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_append_array)(it, array._handle.ptr)
+            notNull(Godot.gdnative.godot_pool_vector3_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +73,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun empty() {
         callNative {
-            checkNotNull(Godot.gdnative12.godot_pool_vector3_array_empty)(it)
+            notNull(Godot.gdnative12.godot_pool_vector3_array_empty)(it)
         }
     }
 
@@ -83,7 +83,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
     operator fun get(idx: Int): Vector3 {
         return Vector3(
             callNative {
-                checkNotNull(Godot.gdnative.godot_pool_vector3_array_get)(it, idx)
+                notNull(Godot.gdnative.godot_pool_vector3_array_get)(it, idx)
             }
         )
     }
@@ -94,7 +94,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun insert(idx: Int, data: Vector3) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector3_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -103,7 +103,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun invert() {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_invert)(it)
+            notNull(Godot.gdnative.godot_pool_vector3_array_invert)(it)
         }
     }
 
@@ -112,7 +112,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun pushBack(data: Vector3) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector3_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -121,7 +121,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun remove(idx: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_remove)(it, idx)
+            notNull(Godot.gdnative.godot_pool_vector3_array_remove)(it, idx)
         }
     }
 
@@ -131,7 +131,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun resize(size: Int) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_resize)(it, size)
+            notNull(Godot.gdnative.godot_pool_vector3_array_resize)(it, size)
         }
     }
 
@@ -140,7 +140,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     operator fun set(idx: Int, data: Vector3) {
         callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            notNull(Godot.gdnative.godot_pool_vector3_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -149,7 +149,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun size(): Int {
         return callNative {
-            checkNotNull(Godot.gdnative.godot_pool_vector3_array_size)(it)
+            notNull(Godot.gdnative.godot_pool_vector3_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector3Array.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolVector3Array.kt
@@ -2,7 +2,6 @@
 
 package godot.core
 
-import godot.gdnative.godot_pool_vector3_array
 import godot.gdnative.godot_pool_vector3_array_layout
 import godot.internal.type.*
 import kotlinx.cinterop.*
@@ -17,14 +16,14 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
     constructor() {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_new)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_new)(it)
         }
     }
 
     constructor(other: PoolVector3Array) {
         _handle = cValue{}
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_new_copy)(it, other._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_new_copy)(it, other._handle.ptr)
         }
     }
 
@@ -54,7 +53,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun append(vector: Vector3) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_append)(it, vector.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_append)(it, vector.getRawMemory(this).reinterpret())
         }
     }
 
@@ -64,7 +63,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun appendArray(array: PoolVector3Array) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_append_array)(it, array._handle.ptr)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_append_array)(it, array._handle.ptr)
         }
     }
 
@@ -73,7 +72,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun empty() {
         callNative {
-            notNull(Godot.gdnative12.godot_pool_vector3_array_empty)(it)
+            nullSafe(Godot.gdnative12.godot_pool_vector3_array_empty)(it)
         }
     }
 
@@ -83,7 +82,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
     operator fun get(idx: Int): Vector3 {
         return Vector3(
             callNative {
-                notNull(Godot.gdnative.godot_pool_vector3_array_get)(it, idx)
+                nullSafe(Godot.gdnative.godot_pool_vector3_array_get)(it, idx)
             }
         )
     }
@@ -94,7 +93,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun insert(idx: Int, data: Vector3) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_insert)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -103,7 +102,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun invert() {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_invert)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_invert)(it)
         }
     }
 
@@ -112,7 +111,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun pushBack(data: Vector3) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_push_back)(it, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_push_back)(it, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -121,7 +120,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun remove(idx: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_remove)(it, idx)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_remove)(it, idx)
         }
     }
 
@@ -131,7 +130,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun resize(size: Int) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_resize)(it, size)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_resize)(it, size)
         }
     }
 
@@ -140,7 +139,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     operator fun set(idx: Int, data: Vector3) {
         callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_set)(it, idx, data.getRawMemory(this).reinterpret())
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_set)(it, idx, data.getRawMemory(this).reinterpret())
         }
     }
 
@@ -149,7 +148,7 @@ class PoolVector3Array : NativeCoreType<godot_pool_vector3_array_layout>, Iterab
      */
     fun size(): Int {
         return callNative {
-            notNull(Godot.gdnative.godot_pool_vector3_array_size)(it)
+            nullSafe(Godot.gdnative.godot_pool_vector3_array_size)(it)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
+++ b/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
@@ -1,0 +1,5 @@
+package godot.internal.type
+
+inline fun <reified T: Any> notNull(obj: T?) : T{
+    return obj!!
+}

--- a/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
+++ b/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
@@ -1,5 +1,5 @@
 package godot.internal.type
 
-inline fun <reified T: Any> notNull(obj: T?) : T{
+inline fun <reified T: Any> nullSafe(obj: T?) : T{
     return obj!!
 }

--- a/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
+++ b/godot-kotlin/godot-library/src/nativeInternal/kotlin/godot/internal/type/nullSafety.kt
@@ -1,5 +1,5 @@
 package godot.internal.type
 
-inline fun <reified T: Any> nullSafe(obj: T?) : T{
+inline fun <reified T: Any> nullSafe(obj: T?) : T {
     return obj!!
 }

--- a/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/global/GD.kt
+++ b/godot-kotlin/godot-library/src/nativePublic/kotlin/godot/global/GD.kt
@@ -4,6 +4,7 @@ import godot.Object
 import godot.RandomNumberGenerator
 import godot.global.gdPrint
 import godot.global.gdResource
+import godot.internal.type.nullSafe
 import kotlinx.cinterop.invoke
 import kotlinx.cinterop.memScoped
 import kotlin.test.assertTrue
@@ -56,7 +57,7 @@ object gd : gdMath, gdCore, gdRandom, gdPrint, gdResource {
     /** Returns whether instance is a valid object (e.g. has not been deleted from memory).*/
     fun isInstanceValid(instance: Object): Boolean {
         return memScoped {
-            checkNotNull(Godot.gdnative11.godot_is_instance_valid)(instance.ptr)
+            nullSafe(Godot.gdnative11.godot_is_instance_valid)(instance.ptr)
         }
     }
 


### PR DESCRIPTION
Replaced CheckNotNull by a nullSafe inline function.
It just cast a nullable type to a non nullable one with "!!"
CheckNotNull is not used anymore because it's not necessary to check for null gdnative function after the initial setup as it's not mutable but just "lateinit" (not really but you get what I mean)

the content of nullSafe can still be easily be replaced by CheckNotNull in case it was really necessary so we can adapt the whole code by changing one line.