### PR TITLE
reinterpret retvar as godot_string and then convert it to Kotlin String in icalls returning String

### DIFF
--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -208,8 +208,12 @@ class ICall(
 
                     returnTypeClassSimpleName == "String" -> {
                         codeBlockBuilder.add(
-                            "    retVar.%M()\n",
-                            MemberName("kotlinx.cinterop", "toKString")
+                            "    retVar.%M<%T>().%M.%M().%M()\n",
+                            MemberName("kotlinx.cinterop", "reinterpret"),
+                            ClassName("godot.gdnative", "godot_string"),
+                            MemberName("kotlinx.cinterop", "pointed"),
+                            MemberName("kotlinx.cinterop", "readValue"),
+                            MemberName("godot.core", "toKString")
                         )
                     }
 


### PR DESCRIPTION
We were trying to convert a pointer to KString, this fixes this behaviour by first reinterpret pointer as `godot_string`, then read its value and anding by converting value to Kotlin String.