### PR TITLE
[Entry-Generation] Replace `Variant.wrap` calls for registered properties and functions

### DIFF
--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/classBuilderDsl.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/classBuilderDsl.kt
@@ -16,13 +16,25 @@ annotation class ClassBuilderDSL
 
 @ClassBuilderDSL
 class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle<T>) {
-    fun <R> function(name: String, rpcMode: RPCMode, body: T.() -> R) {
-        val function = Function0(body)
+
+    fun <R> function(
+        name: String,
+        rpcMode: RPCMode,
+        body: T.() -> R,
+        typeToVariantConverter: (R) -> Variant
+    ) {
+        val function = Function0(body, typeToVariantConverter)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
-    fun <P0, R> function(name: String, rpcMode: RPCMode, body: T.(P0) -> R, argumentConverters: List<(Variant) -> Any?>) {
-        val function = Function1(body, argumentConverters)
+    fun <P0, R> function(
+        name: String,
+        rpcMode: RPCMode,
+        body: T.(P0) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
+    ) {
+        val function = Function1(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
@@ -30,9 +42,10 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
         name: String,
         rpcMode: RPCMode,
         body: T.(P0, P1) -> R,
-        argumentConverters: List<(Variant) -> Any?>
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function2(body, argumentConverters)
+        val function = Function2(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
@@ -40,9 +53,10 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
         name: String,
         rpcMode: RPCMode,
         body: T.(P0, P1, P2) -> R,
-        argumentConverters: List<(Variant) -> Any?>
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function3(body, argumentConverters)
+        val function = Function3(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
@@ -50,63 +64,76 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
         name: String,
         rpcMode: RPCMode,
         body: T.(P0, P1, P2, P3) -> R,
-        argumentConverters: List<(Variant) -> Any?>
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function4(body, argumentConverters)
+        val function = Function4(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function5(body, argumentConverters)
+        val function = Function5(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, P5, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4, P5) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4, P5) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function6(body, argumentConverters)
+        val function = Function6(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, P5, P6, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4, P5, P6) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4, P5, P6) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function7(body, argumentConverters)
+        val function = Function7(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, P5, P6, P7, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4, P5, P6, P7) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4, P5, P6, P7) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function8(body, argumentConverters)
+        val function = Function8(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function9(body, argumentConverters)
+        val function = Function9(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
     fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R> function(
         name: String,
         rpcMode: RPCMode,
-        body: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R, argumentConverters: List<(Variant) -> Any?>
+        body: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R,
+        typeToVariantConverter: (R) -> Variant,
+        variantToTypeConverters: List<(Variant) -> Any?>
     ) {
-        val function = Function10(body, argumentConverters)
+        val function = Function10(body, typeToVariantConverter, variantToTypeConverters)
         classHandle.registerFunction(name, StableRef.create(function).asCPointer(), rpcMode)
     }
 
@@ -117,7 +144,8 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
     fun <K : Any> property(
         name: String,
         property: KMutableProperty1<T, K>,
-        argumentConverter: (Variant) -> Any?,
+        typeToVariantConverter: (K) -> Variant,
+        variantToTypeConverter: (Variant) -> Any?,
         type: Variant.Type,
         default: Variant? = null,
         isVisibleInEditor: Boolean = true,
@@ -125,7 +153,7 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
         hintType: godot_property_hint = godot_property_hint.GODOT_PROPERTY_HINT_NONE,
         hintString: String = ""
     ) {
-        val propertyHandler = MutablePropertyHandler(property, argumentConverter)
+        val propertyHandler = MutablePropertyHandler(property, typeToVariantConverter, variantToTypeConverter)
         classHandle.registerProperty(
             name,
             StableRef.create(propertyHandler).asCPointer(),
@@ -172,7 +200,11 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
                 variantArray.append(it.ordinal.toNaturalT())
             }
         }
-        val propertyHandler = MutablePropertyHandler(property, typeConversionFunctions[Int::class] as (Variant) -> Int?)
+        val propertyHandler = MutablePropertyHandler(
+            property,
+            typeToVariantConversionFunctions[Int::class] ?: error("Could not find intToVariant conversion function. This should never happen. Was it removed/renamed recently?"),
+            variantToTypeConversionFunctions[Int::class] as (Variant) -> Int?
+        )
         classHandle.registerProperty(
             name,
             StableRef.create(propertyHandler).asCPointer(),
@@ -211,6 +243,10 @@ class ClassBuilder<T : Object> internal constructor(val classHandle: ClassHandle
     }
 
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified CONVERTED> getTypeConversionLambda(): (Variant) -> CONVERTED? =
-            (typeConversionFunctions[CONVERTED::class] ?: throw IllegalArgumentException("There is no type conversion function for type ${CONVERTED::class}")) as (Variant) -> CONVERTED?
+    inline fun <reified CONVERTED> getTypeToVariantConversionFunction(): (CONVERTED) -> Variant =
+        (typeToVariantConversionFunctions[CONVERTED::class] ?: throw IllegalArgumentException("There is no variant conversion function from type ${CONVERTED::class}"))
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified CONVERTED> getVariantToTypeConversionFunction(): (Variant) -> CONVERTED? =
+            (variantToTypeConversionFunctions[CONVERTED::class] ?: throw IllegalArgumentException("There is no type conversion function for type ${CONVERTED::class}")) as (Variant) -> CONVERTED?
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/functions.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/functions.kt
@@ -9,10 +9,11 @@ abstract class Function<T : Object, R>(
 }
 
 class Function0<T : Object, R>(
-    val method: T.() -> R
+    val method: T.() -> R,
+    val typeToVariantConverter: (R) -> Variant
 ) : Function<T, R>(0) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance
             )
@@ -22,13 +23,14 @@ class Function0<T : Object, R>(
 
 class Function1<T : Object, P0, R>(
     val method: T.(P0) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(1) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0
+                variantToTypeConverters[0].invoke(args[0]) as P0
             )
         )
     }
@@ -36,14 +38,15 @@ class Function1<T : Object, P0, R>(
 
 class Function2<T : Object, P0, P1, R>(
     val method: T.(P0, P1) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(2) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1
             )
         )
     }
@@ -51,15 +54,16 @@ class Function2<T : Object, P0, P1, R>(
 
 class Function3<T : Object, P0, P1, P2, R>(
     val method: T.(P0, P1, P2) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(3) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2
             )
         )
     }
@@ -67,16 +71,17 @@ class Function3<T : Object, P0, P1, P2, R>(
 
 class Function4<T : Object, P0, P1, P2, P3, R>(
     val method: T.(P0, P1, P2, P3) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(4) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3
             )
         )
     }
@@ -84,17 +89,18 @@ class Function4<T : Object, P0, P1, P2, P3, R>(
 
 class Function5<T : Object, P0, P1, P2, P3, P4, R>(
     val method: T.(P0, P1, P2, P3, P4) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(5) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4
             )
         )
     }
@@ -102,18 +108,19 @@ class Function5<T : Object, P0, P1, P2, P3, P4, R>(
 
 class Function6<T : Object, P0, P1, P2, P3, P4, P5, R>(
     val method: T.(P0, P1, P2, P3, P4, P5) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(6) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4,
-                argumentTypeConverters[5].invoke(args[5]) as P5
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4,
+                variantToTypeConverters[5].invoke(args[5]) as P5
             )
         )
     }
@@ -121,19 +128,20 @@ class Function6<T : Object, P0, P1, P2, P3, P4, P5, R>(
 
 class Function7<T : Object, P0, P1, P2, P3, P4, P5, P6, R>(
     val method: T.(P0, P1, P2, P3, P4, P5, P6) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(7) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4,
-                argumentTypeConverters[5].invoke(args[5]) as P5,
-                argumentTypeConverters[6].invoke(args[6]) as P6
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4,
+                variantToTypeConverters[5].invoke(args[5]) as P5,
+                variantToTypeConverters[6].invoke(args[6]) as P6
             )
         )
     }
@@ -141,20 +149,21 @@ class Function7<T : Object, P0, P1, P2, P3, P4, P5, P6, R>(
 
 class Function8<T : Object, P0, P1, P2, P3, P4, P5, P6, P7, R>(
     val method: T.(P0, P1, P2, P3, P4, P5, P6, P7) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(8) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4,
-                argumentTypeConverters[5].invoke(args[5]) as P5,
-                argumentTypeConverters[6].invoke(args[6]) as P6,
-                argumentTypeConverters[7].invoke(args[7]) as P7
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4,
+                variantToTypeConverters[5].invoke(args[5]) as P5,
+                variantToTypeConverters[6].invoke(args[6]) as P6,
+                variantToTypeConverters[7].invoke(args[7]) as P7
             )
         )
     }
@@ -162,21 +171,22 @@ class Function8<T : Object, P0, P1, P2, P3, P4, P5, P6, P7, R>(
 
 class Function9<T : Object, P0, P1, P2, P3, P4, P5, P6, P7, P8, R>(
     val method: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(9) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4,
-                argumentTypeConverters[5].invoke(args[5]) as P5,
-                argumentTypeConverters[6].invoke(args[6]) as P6,
-                argumentTypeConverters[7].invoke(args[7]) as P7,
-                argumentTypeConverters[8].invoke(args[8]) as P8
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4,
+                variantToTypeConverters[5].invoke(args[5]) as P5,
+                variantToTypeConverters[6].invoke(args[6]) as P6,
+                variantToTypeConverters[7].invoke(args[7]) as P7,
+                variantToTypeConverters[8].invoke(args[8]) as P8
             )
         )
     }
@@ -184,22 +194,23 @@ class Function9<T : Object, P0, P1, P2, P3, P4, P5, P6, P7, P8, R>(
 
 class Function10<T : Object, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R>(
     val method: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R,
-    val argumentTypeConverters: List<(Variant) -> Any?>
+    val typeToVariantConverter: (R) -> Variant,
+    val variantToTypeConverters: List<(Variant) -> Any?>
 ) : Function<T, R>(10) {
     override fun invoke(instance: T, args: List<Variant>): Variant {
-        return Variant.wrap(
+        return typeToVariantConverter.invoke(
             method(
                 instance,
-                argumentTypeConverters[0].invoke(args[0]) as P0,
-                argumentTypeConverters[1].invoke(args[1]) as P1,
-                argumentTypeConverters[2].invoke(args[2]) as P2,
-                argumentTypeConverters[3].invoke(args[3]) as P3,
-                argumentTypeConverters[4].invoke(args[4]) as P4,
-                argumentTypeConverters[5].invoke(args[5]) as P5,
-                argumentTypeConverters[6].invoke(args[6]) as P6,
-                argumentTypeConverters[7].invoke(args[7]) as P7,
-                argumentTypeConverters[8].invoke(args[8]) as P8,
-                argumentTypeConverters[9].invoke(args[9]) as P9
+                variantToTypeConverters[0].invoke(args[0]) as P0,
+                variantToTypeConverters[1].invoke(args[1]) as P1,
+                variantToTypeConverters[2].invoke(args[2]) as P2,
+                variantToTypeConverters[3].invoke(args[3]) as P3,
+                variantToTypeConverters[4].invoke(args[4]) as P4,
+                variantToTypeConverters[5].invoke(args[5]) as P5,
+                variantToTypeConverters[6].invoke(args[6]) as P6,
+                variantToTypeConverters[7].invoke(args[7]) as P7,
+                variantToTypeConverters[8].invoke(args[8]) as P8,
+                variantToTypeConverters[9].invoke(args[9]) as P9
             )
         )
     }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/variantTypeMapping.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/variantTypeMapping.kt
@@ -3,10 +3,30 @@
 package godot.core
 
 import godot.Object
+import godot.internal.type.CoreType
 import kotlin.reflect.KClass
 
+fun directConversionToVariant(obj: Any?) = obj?.let { Variant(obj) } ?: Variant()
+fun intToVariant(obj: Any?) = obj?.let { Variant((obj as Int).toLong()) } ?: Variant()
+fun floatToVariant(obj: Any?) = obj?.let { Variant((obj as Float).toDouble()) } ?: Variant()
+fun variantToVariant(obj: Any?) = obj?.let { obj as Variant } ?: Variant()
+fun coreTypeToVariant(obj: Any?) = obj?.let { (obj as CoreType).toVariant() } ?: Variant()
+
 @PublishedApi
-internal val typeConversionFunctions: Map<KClass<out Any>, (Variant) -> Any?> = mapOf(
+internal val typeToVariantConversionFunctions: Map<KClass<out Any>, (Any?) -> Variant> = mapOf(
+    Boolean::class to ::directConversionToVariant,
+    Int::class to ::intToVariant,
+    Long::class to ::directConversionToVariant,
+    Float::class to ::floatToVariant,
+    Double::class to ::directConversionToVariant,
+    String::class to ::directConversionToVariant,
+    CoreType::class to ::coreTypeToVariant,
+    Variant::class to ::variantToVariant,
+    Object::class to ::directConversionToVariant
+)
+
+@PublishedApi
+internal val variantToTypeConversionFunctions: Map<KClass<out Any>, (Variant) -> Any?> = mapOf(
     Boolean::class to Variant::asBoolean,
     Int::class to Variant::asInt,
     Long::class to Variant::asLong,


### PR DESCRIPTION
This replaces all `Variant.wrap` calls for all registered functions and properties.
~~Signals are not touched yet. Depending on my time today and when you guys do the review i either include it in this PR or in a separate.~~ Do we need to do anything for the signals? we only have one wrap function there:
```kotlin
@PublishedApi
    internal fun connect(
        instance: Object,
        target: Object,
        method: String,
        binds: List<Any>?,
        flags: Long
    ) {
        val extraArgs = VariantArray()
        binds?.forEach { extraArgs.append(Variant.wrap(it)) }
        instance.connect(name, target, method, extraArgs, flags)
    }
```

but we cannot change that as we don't know the type of the binds right?