### PR TITLE
change ReatT to Double in generated api

### DIFF
--- a/buildSrc/src/main/kotlin/godot/codegen/Argument.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/Argument.kt
@@ -37,7 +37,7 @@ class Argument @JsonCreator constructor(
             when (type) {
                 "Color", "Variant" -> "$type($defaultValue)"
                 "Boolean" -> defaultValue.toLowerCase()
-                "RealT" -> intToFloat(defaultValue)
+                "Double" -> intToFloat(defaultValue)
                 "Vector2", "Vector3", "Rect2" -> "$type${defaultValue.replace(",", ".0,")
                     .replace(")", ".0)")}"
                 "Dictionary", "Transform", "Transform2D", "VariantArray", "RID", "PoolVector2Array", "PoolStringArray",

--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -87,10 +87,7 @@ class ICall(
                 codeBlockBuilder.add(
                     "    val retVar = %M<%T>()\n",
                     MemberName("kotlinx.cinterop", "alloc"),
-                    ClassName(
-                        if (returnType == "RealT") "godot.internal.type" else "kotlinx.cinterop",
-                        "${returnType}Var"
-                    )
+                    ClassName("kotlinx.cinterop", "${returnType}Var")
                 )
             } else {
                 codeBlockBuilder.add(

--- a/buildSrc/src/main/kotlin/godot/codegen/TypeCast.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/TypeCast.kt
@@ -50,7 +50,7 @@ private val kotlinReservedNames = listOf(
     "object"
 )
 
-private val primitives = listOf("Long", "RealT", "Boolean", "Unit")
+private val primitives = listOf("Long", "Double", "Boolean", "Unit")
 
 fun String.escapeUnderscore(): String {
     if (this == "") return this
@@ -88,14 +88,12 @@ fun String.getPackage() =
             } else {
                 thisString = thisString.replace("::", ".").split(".")[0]
                 when {
-                    this == "RealT" -> "godot.internal.type"
                     thisString.isPrimitive() || thisString == "String" -> "kotlin"
                     thisString.isCoreType() -> "godot.core"
                     else -> "godot"
                 }
             }
         }
-        this == "RealT" -> "godot.internal.type"
         isPrimitive() || this == "String" -> "kotlin"
         isCoreType()  -> "godot.core"
         else -> "godot"
@@ -145,7 +143,7 @@ fun String.convertToSnakeCase(): String =
 fun String.convertTypeToKotlin(): String {
     return when {
         this == "int" -> "Long"
-        this == "float" -> "RealT"
+        this == "float" -> "Double"
         this == "bool" -> "Boolean"
         this == "void" -> "Unit"
         this == "Array" -> "VariantArray"
@@ -166,7 +164,7 @@ fun String.convertTypeForICalls(): String {
 
 fun String.defaultValue(): String = when (this) {
     "Long" -> "0"
-    "RealT" -> "0.0"
+    "Double" -> "0.0"
     "Boolean" -> "false"
     else -> throw Exception("$this is not a primitive type.")
 }


### PR DESCRIPTION
This remove use of `RealT` in favor of `Double` in generated API code, according to #185 
I am not able to test it right now as I encounter linking error on OSX, when compiling samples:
```
  "_godot_color_set_r", referenced from:
      _godot_gdnative_godot_color_set_r_wrapper3 in libgodot-library-cinterop-gdnative-cache.a(result.o)
     (maybe you meant: knifunptr_godot_gdnative3_godot_color_set_r, _godot_gdnative_godot_color_set_r_wrapper3 )
  "_godot_string_to_int64", referenced from:
      _godot_gdnative_godot_string_to_int64_wrapper691 in libgodot-library-cinterop-gdnative-cache.a(result.o)
     (maybe you meant: knifunptr_godot_gdnative691_godot_string_to_int64, _godot_gdnative_godot_string_to_int64_wrapper691 )
  "_godot_string_char_uppercase", referenced from:
      _godot_gdnative_godot_string_char_uppercase_wrapper708 in libgodot-library-cinterop-gdnative-cache.a(result.o)
     (maybe you meant: knifunptr_godot_gdnative708_godot_string_char_uppercase, _godot_gdnative_godot_string_char_uppercase_wrapper708 )
  "_godot_pool_string_array_invert", referenced from:
      _godot_gdnative_godot_pool_string_array_invert_wrapper232 in libgodot-library-cinterop-gdnative-cache.a(result.o)
     (maybe you meant: knifunptr_godot_gdnative232_godot_pool_string_array_invert, _godot_gdnative_godot_pool_string_array_invert_wrapper232 )
  "_godot_quat_new_with_euler", referenced from:
      _godot_gdnative_godot_quat_new_with_euler_wrapper73 in libgodot-library-cinterop-gdnative-cache.a(result.o)
     (maybe you meant: knifunptr_godot_gdnative73_godot_quat_new_with_euler, _godot_gdnative_godot_quat_new_with_euler_wrapper73 )
ld: symbol(s) not found for architecture x86_64
```
I have the same behaviour with `master-merge` branch.
Can you test it on Linux and Windows ? As I am away from home I only have a macbook with me.