### PR TITLE
Enhancement/gdstring as inline class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build
 
 
 /samples/mini-games/.import/
+
+# OSX
+.DS_Store

--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -187,7 +187,7 @@ class ICall(
                     returnTypeClassSimpleName == "String" -> {
                         codeBlockBuilder.add(
                             "    %M(retVar).toKString()\n",
-                            MemberName("godot.core", "from")
+                            MemberName("godot.core", "String")
                         )
                     }
 
@@ -241,7 +241,7 @@ class ICall(
         if (it.value.type == "String") {
             codeBlockBuilder.add(
                 "    %M(args[${it.index}]!!).destroy(this)\n",
-                MemberName("godot.core", "from")
+                MemberName("godot.core", "String")
             )
         }
     }

--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -184,8 +184,8 @@ class ICall(
 
                     returnTypeClassSimpleName == "String" -> {
                         codeBlockBuilder.add(
-                            "    %M(retVar)\n",
-                            MemberName("godot.core", "String")
+                            "    %M(retVar).toKString()\n",
+                            MemberName("godot.core", "from")
                         )
                     }
 

--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -187,7 +187,7 @@ class ICall(
                     returnTypeClassSimpleName == "String" -> {
                         codeBlockBuilder.add(
                             "    %M(retVar).toKString()\n",
-                            MemberName("godot.core", "String")
+                            MemberName("godot.core", "GdString")
                         )
                     }
 
@@ -241,7 +241,7 @@ class ICall(
         if (it.value.type == "String") {
             codeBlockBuilder.add(
                 "    %M(args[${it.index}]!!).destroy(this)\n",
-                MemberName("godot.core", "String")
+                MemberName("godot.core", "GdString")
             )
         }
     }

--- a/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/ICall.kt
@@ -116,8 +116,8 @@ class ICall(
             when {
                 value.type == "String" -> {
                     codeBlockBuilder.add(
-                        "    args[$i] = arg$i$nullInstruction.%M$nullInstruction.ptr\n",
-                        MemberName("kotlinx.cinterop", "cstr")
+                        "    args[$i] = arg$i$nullInstruction.%M()$nullInstruction.value$nullInstruction.ptr\n",
+                        MemberName("godot.core", "toGDString")
                     )
                 }
                 value.type == "VariantArray" || value.type == "Variant" -> {
@@ -153,6 +153,7 @@ class ICall(
                     MemberName("kotlinx.cinterop", "invoke"),
                     MemberName("kotlinx.cinterop", "ptr")
                 )
+                destroyStringArgs(codeBlockBuilder)
                 codeBlockBuilder.add(
                     "    ret = retVar.%M\n",
                     MemberName("kotlinx.cinterop", "value")
@@ -163,6 +164,7 @@ class ICall(
                     ClassName("godot.core", "Godot"),
                     MemberName("kotlinx.cinterop", "invoke")
                 )
+                destroyStringArgs(codeBlockBuilder)
                 val returnTypeClassSimpleName = returnTypeClass.simpleName
 
                 when {
@@ -203,6 +205,7 @@ class ICall(
                 ClassName("godot.core", "Godot"),
                 MemberName("kotlinx.cinterop", "invoke")
             )
+            destroyStringArgs(codeBlockBuilder)
         }
 
         codeBlockBuilder.add("}\n")
@@ -231,6 +234,15 @@ class ICall(
             }
 
             spec.addParameter("arg${it.index}", argumentType)
+        }
+    }
+
+    private fun destroyStringArgs(codeBlockBuilder: CodeBlock.Builder) = arguments.withIndex().forEach {
+        if (it.value.type == "String") {
+            codeBlockBuilder.add(
+                "    %M(args[${it.index}]!!).destroy(this)\n",
+                MemberName("godot.core", "from")
+            )
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/Godot.kt
@@ -91,7 +91,7 @@ object Godot {
 
     internal fun print(message: String) {
         memScoped {
-            nullSafe(gdnative.godot_print)(message.toGDString().ptr)
+            nullSafe(gdnative.godot_print)(message.toGDString().value.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GdString.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GdString.kt
@@ -12,9 +12,10 @@ inline class GdString(val value: CValue<godot_string_layout>) {
     internal fun toKString(): String {
         return memScoped {
             val charString = nullSafe(Godot.gdnative.godot_string_utf8)(this@GdString.value.ptr)
-            val ret = nullSafe(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
+            val charPtr = charString.ptr
+            val ret = nullSafe(Godot.gdnative.godot_char_string_get_data)(charPtr)?.toKString()
                 ?: throw NullPointerException("Failed to convert Godot-string to Kotlin-string")
-            nullSafe(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
+            nullSafe(Godot.gdnative.godot_char_string_destroy)(charPtr)
             destroy(this@memScoped)
             ret
         }
@@ -34,9 +35,10 @@ internal fun String.getRawMemory(memScope: MemScope) =
 
 internal fun String.toGDString() = memScoped {
     GdString(cValue {
-        nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
+        val ptr = this.ptr
+        nullSafe(Godot.gdnative.godot_string_new)(ptr)
         nullSafe(Godot.gdnative.godot_string_parse_utf8)(
-            this.ptr,
+            ptr,
             this@toGDString.cstr.ptr
         )
     })
@@ -45,9 +47,10 @@ internal fun String.toGDString() = memScoped {
 internal fun <T> String.asGDString(block: MemScope.(GdString) -> T): T {
     return memScoped {
         val gdString = GdString(cValue {
-            nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
+            val ptr = this.ptr
+            nullSafe(Godot.gdnative.godot_string_new)(ptr)
             nullSafe(Godot.gdnative.godot_string_parse_utf8)(
-                this.ptr,
+                ptr,
                 this@asGDString.cstr.ptr
             )
         })

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GdString.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GdString.kt
@@ -25,8 +25,8 @@ inline class GdString(val value: CValue<godot_string_layout>) {
 }
 
 //From Godot to Kotlin
-internal fun String(ptr: COpaquePointer) = String(ptr.reinterpret())
-internal fun String(ptr: CPointer<godot_string>) = GdString(ptr.pointed.readValue())
+internal fun GdString(ptr: COpaquePointer) = GdString(ptr.reinterpret())
+internal fun GdString(ptr: CPointer<godot_string>) = GdString(ptr.pointed.readValue())
 
 //From Kotlin to Godot
 internal fun String.getRawMemory(memScope: MemScope) =

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/GodotArray.kt
@@ -112,7 +112,7 @@ abstract class GodotArray<T> internal constructor() : NativeCoreType<godot_array
      */
     fun sortCustom(obj: Object, func: String) {
         return callNative {
-            nullSafe(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_array_sort_custom)(it, obj.ptr, func.toGDString().value.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/NodePath.kt
@@ -15,7 +15,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     val path: String
         get() {
             return callNative {
-                nullSafe(Godot.gdnative.godot_node_path_as_string)(it)
+                GdString(nullSafe(Godot.gdnative.godot_node_path_as_string)(it))
             }.toKString()
         }
 
@@ -23,14 +23,14 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
     constructor() {
         _handle = cValue {}
         callNative {
-            nullSafe(Godot.gdnative.godot_node_path_new)(it, "".toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new)(it, "".toGDString().value.ptr)
         }
     }
 
     constructor(from: String) {
         _handle = cValue {}
         callNative {
-            nullSafe(Godot.gdnative.godot_node_path_new)(it, from.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_node_path_new)(it, from.toGDString().value.ptr)
         }
     }
 
@@ -70,7 +70,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getName(idx: Int): String {
         return callNative {
-            nullSafe(Godot.gdnative.godot_node_path_get_name)(it, idx)
+            GdString(nullSafe(Godot.gdnative.godot_node_path_get_name)(it, idx))
         }.toKString()
 
     }
@@ -99,7 +99,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getSubname(idx: Int): String {
         return callNative {
-            nullSafe(Godot.gdnative.godot_node_path_get_subname)(it, idx).toKString()
+            GdString(nullSafe(Godot.gdnative.godot_node_path_get_subname)(it, idx)).toKString()
         }
     }
 
@@ -135,7 +135,7 @@ class NodePath : NativeCoreType<godot_node_path_layout> {
      */
     fun getConcatenatedSubnames(): String {
         return callNative {
-            nullSafe(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it).toKString()
+            GdString(nullSafe(Godot.gdnative.godot_node_path_get_concatenated_subnames)(it)).toKString()
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
@@ -7,52 +7,52 @@ import godot.gdnative.godot_string_layout
 import godot.internal.type.nullSafe
 import kotlinx.cinterop.*
 
-typealias GdString = CValue<godot_string_layout>
+inline class GdString(val value: CValue<godot_string_layout>) {
 
-//From Godot to Kotlin
-internal fun String(ptr: COpaquePointer) = String(ptr.reinterpret())
-
-internal fun String(ptr: CPointer<godot_string>) = ptr.pointed.readValue().toKString()
-
-internal fun GdString.toKString(): String {
-    return memScoped {
-        val charString = nullSafe(Godot.gdnative.godot_string_utf8)(this@toKString.ptr)
-        val ret = nullSafe(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
-            ?: throw NullPointerException("Failed to convert Godot-string to Kotlin-string")
-        nullSafe(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
-        nullSafe(Godot.gdnative.godot_string_destroy)(this@toKString.ptr)
-        ret
-    }
-}
-
-//From Kotlin to Godot
-internal fun String.getRawMemory(memScope: MemScope): COpaquePointer {
-    return this.toGDString().getPointer(memScope)
-}
-
-internal fun String.toGDString(): GdString {
-    return memScoped {
-        cValue {
-            nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
-            nullSafe(Godot.gdnative.godot_string_parse_utf8)(
-                this.ptr,
-                this@toGDString.cstr.ptr
-            )
+    internal fun toKString(): String {
+        return memScoped {
+            val charString = nullSafe(Godot.gdnative.godot_string_utf8)(this@GdString.value.ptr)
+            val ret = nullSafe(Godot.gdnative.godot_char_string_get_data)(charString.ptr)?.toKString()
+                ?: throw NullPointerException("Failed to convert Godot-string to Kotlin-string")
+            nullSafe(Godot.gdnative.godot_char_string_destroy)(charString.ptr)
+            destroy(this@memScoped)
+            ret
         }
     }
+
+    internal fun destroy(memScope: MemScope) =
+        nullSafe(Godot.gdnative.godot_string_destroy)(this.value.getPointer(memScope))
+}
+
+//From Godot to Kotlin
+internal fun from(ptr: COpaquePointer) = from(ptr.reinterpret())
+internal fun from(ptr: CPointer<godot_string>) = GdString(ptr.pointed.readValue())
+
+//From Kotlin to Godot
+internal fun String.getRawMemory(memScope: MemScope) =
+    this.toGDString().value.getPointer(memScope)
+
+internal fun String.toGDString() = memScoped {
+    GdString(cValue {
+        nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
+        nullSafe(Godot.gdnative.godot_string_parse_utf8)(
+            this.ptr,
+            this@toGDString.cstr.ptr
+        )
+    })
 }
 
 internal fun <T> String.asGDString(block: MemScope.(GdString) -> T): T {
     return memScoped {
-        val gdString = cValue<godot_string_layout> {
+        val gdString = GdString(cValue {
             nullSafe(Godot.gdnative.godot_string_new)(this.ptr)
             nullSafe(Godot.gdnative.godot_string_parse_utf8)(
                 this.ptr,
                 this@asGDString.cstr.ptr
             )
-        }
+        })
         val ret: T = block(this, gdString)
-        nullSafe(Godot.gdnative.godot_string_destroy)(gdString.ptr)
+        nullSafe(Godot.gdnative.godot_string_destroy)(gdString.value.ptr)
         ret
     }
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/String.kt
@@ -25,8 +25,8 @@ inline class GdString(val value: CValue<godot_string_layout>) {
 }
 
 //From Godot to Kotlin
-internal fun from(ptr: COpaquePointer) = from(ptr.reinterpret())
-internal fun from(ptr: CPointer<godot_string>) = GdString(ptr.pointed.readValue())
+internal fun String(ptr: COpaquePointer) = String(ptr.reinterpret())
+internal fun String(ptr: CPointer<godot_string>) = GdString(ptr.pointed.readValue())
 
 //From Kotlin to Godot
 internal fun String.getRawMemory(memScope: MemScope) =

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/Variant.kt
@@ -317,7 +317,7 @@ inline class Variant internal constructor(internal val _handle: CValue<godot_var
      */
     fun asString(): String {
         return memScoped {
-            val gdString = nullSafe(Godot.gdnative.godot_variant_as_string)(_handle.ptr)
+            val gdString = GdString(nullSafe(Godot.gdnative.godot_variant_as_string)(_handle.ptr))
             gdString.toKString()
         }
     }
@@ -805,7 +805,7 @@ fun Variant(from: Double) = Variant(
 fun Variant(from: String) = Variant(
     memScoped {
         cValue<godot_variant> {
-            nullSafe(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_variant_new_string)(this.ptr, from.toGDString().value.ptr)
         }
     }
 )

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/EnumArray.kt
@@ -44,7 +44,7 @@ class EnumArray<E : Enum<E>>(val mapper: (Int) -> E) : GodotArray<E>() {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/ObjectArray.kt
@@ -47,7 +47,7 @@ class ObjectArray<T : Object> : GodotArray<T> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/VariantArray.kt
@@ -116,7 +116,7 @@ class VariantArray : GodotArray<Variant> {
                 it,
                 value._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/core/CoreArray.kt
@@ -53,7 +53,7 @@ abstract class CoreArray<T : CoreType> : GodotArray<T> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/BoolVariantArray.kt
@@ -53,7 +53,7 @@ class BoolVariantArray : GodotArray<Boolean> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/IntVariantArray.kt
@@ -69,7 +69,7 @@ class IntVariantArray : GodotArray<NaturalT> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/RealVariantArray.kt
@@ -62,7 +62,7 @@ class RealVariantArray : GodotArray<RealT> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/array/primitive/StringVariantArray.kt
@@ -60,7 +60,7 @@ class StringVariantArray : GodotArray<String> {
                 it,
                 value.toVariant()._handle.ptr,
                 obj.ptr,
-                func.toGDString().ptr,
+                func.toGDString().value.ptr,
                 before
             )
         }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/pool/PoolStringArray.kt
@@ -53,7 +53,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun append(s: String) {
         callNative {
-            nullSafe(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_append)(it, s.toGDString().value.ptr)
         }
     }
 
@@ -81,7 +81,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun get(idx: Int): String {
         return callNative {
-            nullSafe(Godot.gdnative.godot_pool_string_array_get)(it, idx)
+            GdString(nullSafe(Godot.gdnative.godot_pool_string_array_get)(it, idx))
         }.toKString()
     }
 
@@ -91,7 +91,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun insert(idx: Int, data: String) {
         callNative {
-            nullSafe(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_insert)(it, idx, data.toGDString().value.ptr)
         }
     }
 
@@ -109,7 +109,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     fun pushBack(data: String) {
         callNative {
-            nullSafe(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_push_back)(it, data.toGDString().value.ptr)
         }
     }
 
@@ -137,7 +137,7 @@ class PoolStringArray : NativeCoreType<godot_pool_string_array_layout>, Iterable
      */
     operator fun set(idx: Int, data: String) {
         callNative {
-            nullSafe(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().ptr)
+            nullSafe(Godot.gdnative.godot_pool_string_array_set)(it, idx, data.toGDString().value.ptr)
         }
     }
 

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/File.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/File.kt
@@ -5,40 +5,40 @@ import kotlinx.cinterop.invoke
 
 /** If the string is a valid file path, returns the base directory name. */
 fun String.getBaseDir() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_get_base_dir)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_get_base_dir)(it.value.ptr)).toKString()
 }
 
 /** If the string is a valid file path, returns the full file path without the extension. */
 fun String.getBaseName() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_get_basename)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_get_basename)(it.value.ptr)).toKString()
 }
 
 /** If the string is a valid file path, returns the extension. */
 fun String.getExtension() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_get_extension)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_get_extension)(it.value.ptr)).toKString()
 }
 
 /** If the string is a valid file path, returns the filename. */
 fun String.getFile() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_get_file)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_get_file)(it.value.ptr)).toKString()
 }
 
 /** If the string is a path to a file or directory, returns true if the path is absolute. */
 fun String.isAbsolutePath(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_abs_path)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_abs_path)(it.value.ptr)
 }
 
 /** If the string is a path to a file or directory, returns true if the path is relative. */
 fun String.isRelativePath(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_rel_path)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_rel_path)(it.value.ptr)
 }
 
 /**  Return true if the string is a path to a Godot resource. */
 fun String.isResourceFile(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_resource_file)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_resource_file)(it.value.ptr)
 }
 
 /** Simplify the path if there is redundant relative paths inside. */
 fun String.simplifyPath() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_simplify_path)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_simplify_path)(it.value.ptr)).toKString()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Hash.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Hash.kt
@@ -5,30 +5,30 @@ import kotlinx.cinterop.invoke
 
 /** Hashes the string and returns a 32-bit integer. */
 fun String.hash() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_hash)(it.ptr).toInt()
+    nullSafe(Godot.gdnative.godot_string_hash)(it.value.ptr).toInt()
 }
 
 /** Hashes the string and returns a 64-bit integer. */
 fun String.hash64() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_hash64)(it.ptr).toLong()
+    nullSafe(Godot.gdnative.godot_string_hash64)(it.value.ptr).toLong()
 }
 
 /** Returns the MD5 hash of the string as an array of bytes. */
 fun String.md5Buffer() = asGDString {
-    PoolByteArray(nullSafe(Godot.gdnative.godot_string_md5_buffer)(it.ptr))
+    PoolByteArray(nullSafe(Godot.gdnative.godot_string_md5_buffer)(it.value.ptr))
 }
 
 /** Returns the MD5 hash of the string as a string. */
 fun String.md5Text() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_md5_text)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_md5_text)(it.value.ptr)).toKString()
 }
 
 /** Returns the SHA-256 hash of the string as an array of bytes. */
 fun String.sha256Buffer() = asGDString {
-    PoolByteArray(nullSafe(Godot.gdnative.godot_string_sha256_buffer)(it.ptr))
+    PoolByteArray(nullSafe(Godot.gdnative.godot_string_sha256_buffer)(it.value.ptr))
 }
 
 /** Returns the SHA-256 hash of the string as a string. */
 fun String.sha256Text() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_sha256_text)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_sha256_text)(it.value.ptr)).toKString()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/UnEscape.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/UnEscape.kt
@@ -5,55 +5,55 @@ import kotlinx.cinterop.invoke
 
 /** Returns a copy of the string with special characters escaped using the C language standard. */
 fun String.cEscape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_c_escape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_c_escape)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with special characters escaped using the C language standard. */
 fun String.cUnescapeMulti() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_c_escape_multiline)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_c_escape_multiline)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with escaped characters replaced by their meanings according to the C language standard. */
 fun String.cUnescape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_c_unescape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_c_unescape)(it.value.ptr)).toKString()
 }
 
 /** Escapes (encodes) a string to URL friendly format. Also referred to as 'URL encode'. */
 fun String.httpEscape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_http_escape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_http_escape)(it.value.ptr)).toKString()
 }
 
 /** Unescapes (decodes) a string in URL encoded format. Also referred to as 'URL decode'. */
 fun String.httpUnescape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_http_unescape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_http_unescape)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with special characters escaped using the JSON standard. */
 fun String.jsonEscape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_json_escape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_json_escape)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with special characters escaped using the XML standard.. */
 fun String.xmlEscape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_xml_escape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_xml_escape)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with special characters escaped using the XML standard. */
 fun String.xlmEscapeWithQuotes() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_xml_escape_with_quotes)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_xml_escape_with_quotes)(it.value.ptr)).toKString()
 }
 
 /** Returns a copy of the string with escaped characters replaced by their meanings according to the XML standard. */
 fun String.xmlUnescape() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_xml_unescape)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_xml_unescape)(it.value.ptr)).toKString()
 }
 
 /** Decode a percent-encoded string. See percent_encode. */
 fun String.percentDecode() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_percent_decode)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_percent_decode)(it.value.ptr)).toKString()
 }
 
 /** Percent-encodes a string. Encodes parameters in a URL when sending a HTTP GET request (and bodies of form-urlencoded POST requests). */
 fun String.percentEncode() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_percent_encode)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_percent_encode)(it.value.ptr)).toKString()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Util.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Util.kt
@@ -1,8 +1,8 @@
 package godot.core.type.string
 
+import godot.core.GdString
 import godot.core.Godot
 import godot.core.asGDString
-import godot.core.toKString
 import godot.internal.type.nullSafe
 import godot.internal.type.toRealT
 import kotlinx.cinterop.invoke
@@ -10,16 +10,16 @@ import kotlinx.cinterop.invoke
 /** Returns the similarity index of the text compared to this string. 1 means totally similar and 0 means totally dissimilar. */
 fun String.similarity(other: String) = asGDString { first ->
     other.asGDString { second ->
-        nullSafe(Godot.gdnative.godot_string_similarity)(first.ptr, second.ptr).toRealT()
+        nullSafe(Godot.gdnative.godot_string_similarity)(first.value.ptr, second.value.ptr).toRealT()
     }
 }
 
 /** Convert a CamelCase string to a Snake_Case one */
 fun String.camelcaseToUnderscore() = asGDString {
-    nullSafe(Godot.gdnative.godot_string_camelcase_to_underscore)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_camelcase_to_underscore)(it.value.ptr)).toKString()
 }
 
 /** Convert a CamelCase string to a snake_case one */
 fun String.camelcaseToUnderscoreLowercased(other: String) = asGDString {
-    nullSafe(Godot.gdnative.godot_string_camelcase_to_underscore_lowercased)(it.ptr).toKString()
+    GdString(nullSafe(Godot.gdnative.godot_string_camelcase_to_underscore_lowercased)(it.value.ptr)).toKString()
 }

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Validation.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/type/string/Validation.kt
@@ -5,34 +5,34 @@ import kotlinx.cinterop.invoke
 
 /** Returns true if this string contains a valid float. */
 fun String.isValidFloat(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_float)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_valid_float)(it.value.ptr)
 }
 
 /** Returns true if this string contains a valid hexadecimal number.
  * If with_prefix is true, then a validity of the hexadecimal number is determined by 0x prefix, for instance: 0xDEADC0DE.
  * */
 fun String.isValidHex(withPrefix: Boolean): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_hex_number)(it.ptr, withPrefix)
+    nullSafe(Godot.gdnative.godot_string_is_valid_hex_number)(it.value.ptr, withPrefix)
 }
 
 /** Returns true if this string contains a valid color in hexadecimal HTML notation.
  * Other HTML notations such as named colors or hsl() colors aren't considered valid by this method and will return false. */
 fun String.isValidHtmlColor(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_html_color)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_valid_html_color)(it.value.ptr)
 }
 
 /** Returns true if this string is a valid identifier.
  * A valid identifier may contain only letters, digits and underscores (_) and the first character may not be a digit. */
 fun String.isValidIdentifier(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_identifier)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_valid_identifier)(it.value.ptr)
 }
 
 /** Returns true if this string contains a valid integer. */
 fun String.isValidInteger(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_integer)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_valid_integer)(it.value.ptr)
 }
 
 /** Returns true if this string contains a valid IP address. */
 fun String.isValidAdress(): Boolean = asGDString {
-    nullSafe(Godot.gdnative.godot_string_is_valid_ip_address)(it.ptr)
+    nullSafe(Godot.gdnative.godot_string_is_valid_ip_address)(it.value.ptr)
 }


### PR DESCRIPTION
This transforms typealias GdString to inline class, to simplify use of Godot Strings.
This convert String arguments of icalls to GdString before passing them to godot, and then destroy them when not used anymore.