### PR TITLE
Drop enum value constants

### DIFF
--- a/buildSrc/src/main/kotlin/godot/codegen/Class.kt
+++ b/buildSrc/src/main/kotlin/godot/codegen/Class.kt
@@ -277,7 +277,11 @@ class Class @JsonCreator constructor(
     }
 
     private fun generateConstants(baseCompanion: TypeSpec.Builder) {
-        constants.forEach { (key, value) ->
+        // for easy lookup
+        val allEnumValues = enums.flatMap { it.values.keys }
+            .toSet()
+        constants.filter { !allEnumValues.contains(it.key) }
+            .forEach { (key, value) ->
             baseCompanion.addProperty(
                 PropertySpec
                     .builder(key, Long::class)


### PR DESCRIPTION
This PR drops the constant values that are actually enum values. If we had the generated classes committed we could have seen a diff of the actual changes :P.