### PR TITLE
Rework noInitZone

### DIFF
--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/ClassHandle.kt
@@ -17,9 +17,7 @@ internal class ClassHandle<T : Object>(
     private val disposables = mutableListOf<COpaquePointer>()
 
     fun wrap(instance: COpaquePointer): T {
-        return Godot.noInitZone {
-            factory().also { it.ptr = instance }
-        }
+        return Godot.instantiateWith(instance, factory)
     }
 
     fun init() {

--- a/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
+++ b/godot-kotlin/godot-library/src/nativeCore/kotlin/godot/core/TypeManager.kt
@@ -53,10 +53,8 @@ internal object TypeManager {
      */
     fun wrap(ptr: COpaquePointer): Object {
         val tag = getTagFromInstancePtr(ptr)
-        val factory = tag ?: { Godot.noInitZone { Object(null) } }
-        val instance = factory()
-        instance.ptr = ptr
-        return instance
+        val factory = tag ?: ::Object
+        return Godot.instantiateWith(ptr, factory)
     }
 
     private fun createAndRegisterTag(factory: () -> Object): COpaquePointer {
@@ -70,8 +68,7 @@ internal object TypeManager {
 
     private fun getTagFromInstancePtr(ptr: COpaquePointer): (() -> Object)? {
         return memScoped {
-            val obj = Godot.noInitZone { Object() }
-            obj.ptr = ptr
+            val obj = Godot.instantiateWith(ptr, ::Object)
             val className = obj.getClass()
             // user defined type
             // this should be first otherwise casting to a user defined type won't work!


### PR DESCRIPTION
This ensures that noInitZone only affects the first call to `shouldInitPtr`. Previously this was causing issues with object properties not being initialized.

```kotlin
class MyScript : Spatial() {
	val label = Label()
}
```

The problem here is when `Label()` is called it is still within the `noInitZone`, causing the underlying `ptr` to be not initialized.